### PR TITLE
Two Sources under one name share a ration instead of trapping

### DIFF
--- a/TechPulse.xcodeproj/project.pbxproj
+++ b/TechPulse.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		4A2B4EC62E3B4BF6E10CD9CC /* SelectableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8740BCA165AACC9103823F /* SelectableText.swift */; };
 		4BF6AF14EDF50A14C3F4205E /* TopicSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C4D1DACE42EDDAAD7384F6 /* TopicSearchService.swift */; };
 		4C714C5DB37A3929083FB727 /* KnowledgeEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD1BC18D4319A7AA8A7A80A /* KnowledgeEngine.swift */; };
+		4D46D1E8FE76F4B8D8824B3E /* FeedSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CD7DA32E69836E54817449D /* FeedSyncTests.swift */; };
 		54270DCF1E686461F4D799E8 /* FeedSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F913F99EDEF0C8346A46BF8 /* FeedSource.swift */; };
 		55AEB1106174B5C14FB36FA2 /* TechPulseApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCD8E2B92F580179B914CAB /* TechPulseApp.swift */; };
 		55C48AE6CB76FD8C4B1ADA6A /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E4491DBD576D7C3A194CF7 /* FeedView.swift */; };
@@ -174,6 +175,7 @@
 		4C2E5EA53D43AAA6E9661699 /* WordSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordSelection.swift; sourceTree = "<group>"; };
 		4E8740BCA165AACC9103823F /* SelectableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableText.swift; sourceTree = "<group>"; };
 		571D5671CDF5C25BAA89D44C /* PackLibraryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackLibraryView.swift; sourceTree = "<group>"; };
+		5CD7DA32E69836E54817449D /* FeedSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSyncTests.swift; sourceTree = "<group>"; };
 		5E0AC48BA00E4E792E92DD6F /* Journey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Journey.swift; sourceTree = "<group>"; };
 		617B35B67651116A05F5ADB6 /* TechPulse.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = TechPulse.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		626B44DBD4047ED09444071D /* FeedSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSyncService.swift; sourceTree = "<group>"; };
@@ -314,6 +316,7 @@
 				AFF3E26CD07C160305C33BD7 /* CoreadScoringTests.swift */,
 				43F70C6D332EB69325A6D616 /* ExplainPromptTests.swift */,
 				941B6A636A34EAB579EEDCC0 /* ExplainRouteTests.swift */,
+				5CD7DA32E69836E54817449D /* FeedSyncTests.swift */,
 				672DB5C708F62EDBA9A7C6FE /* FullTextServiceTests.swift */,
 				EF5B6B879A9E3F1DF5D2F514 /* GraphRenderingTests.swift */,
 				73FEFD3493ED4C1DAEF0BA1F /* HabitEngineTests.swift */,
@@ -573,6 +576,7 @@
 				F5887E0869B482BB64DF7D0E /* CoreadScoringTests.swift in Sources */,
 				8FFEF7536EEB88B4ADF5CB65 /* ExplainPromptTests.swift in Sources */,
 				4823EDDF5E54AFD727A94E38 /* ExplainRouteTests.swift in Sources */,
+				4D46D1E8FE76F4B8D8824B3E /* FeedSyncTests.swift in Sources */,
 				E672C856D5A49E3B95D90AE1 /* FullTextServiceTests.swift in Sources */,
 				03F66B9690BA203BD931B93F /* GraphRenderingTests.swift in Sources */,
 				7E39B00F888424CFF59C19D9 /* HabitEngineTests.swift in Sources */,

--- a/TechPulse/Services/FeedSyncService.swift
+++ b/TechPulse/Services/FeedSyncService.swift
@@ -11,7 +11,10 @@ enum FeedSyncService {
     /// Daily intake cap across ALL feeds. 30 fresh articles a day is plenty
     /// for a starting reader — an overflowing feed kills the habit
     /// (Atomic Habits: make it easy; an achievable pile gets opened).
-    private static let dailyIntakeLimit = 30
+    static let dailyIntakeLimit = 30
+
+    /// Articles a Source with nothing cached may take OUTSIDE the daily cap.
+    static let newSourceAllowance = 5
 
     /// Descriptive User-Agent: some hosts (notably reddit, which serves the
     /// Kaggle community feed) throttle or 403 default CFNetwork agents.
@@ -57,11 +60,18 @@ enum FeedSyncService {
         // New-source bootstrap: a source with nothing cached may take a few
         // articles OUTSIDE the daily cap — otherwise a source added on a day
         // whose intake is already spent shows an empty tag until tomorrow.
+        //
+        // Keyed by name because an Article names its source, so "has this
+        // source cached anything?" is a name-level question. Names are not
+        // unique — subscription is deduplicated by URL everywhere it happens —
+        // so two sources can land on one key, and the two of them then share a
+        // single ration rather than trapping on the way in (#23).
         let cachedSourceNames = Set(existing.map(\.sourceName))
         var bootstrap: [String: Int] = Dictionary(
-            uniqueKeysWithValues: sources
+            sources
                 .filter { !cachedSourceNames.contains($0.name) }
-                .map { ($0.name, 5) }
+                .map { ($0.name, newSourceAllowance) },
+            uniquingKeysWith: { ration, _ in ration }
         )
 
         // Pool candidates across all feeds, newest first, so the cap keeps the

--- a/TechPulse/Services/FeedSyncService.swift
+++ b/TechPulse/Services/FeedSyncService.swift
@@ -13,7 +13,9 @@ enum FeedSyncService {
     /// (Atomic Habits: make it easy; an achievable pile gets opened).
     static let dailyIntakeLimit = 30
 
-    /// Articles a Source with nothing cached may take OUTSIDE the daily cap.
+    /// Articles a Source with nothing cached may take OUTSIDE the daily cap,
+    /// so that a Source added on a day whose intake is already spent shows
+    /// something rather than an empty tag until tomorrow.
     static let newSourceAllowance = 5
 
     /// Descriptive User-Agent: some hosts (notably reddit, which serves the
@@ -57,21 +59,15 @@ enum FeedSyncService {
         var allowance = max(0, dailyIntakeLimit - addedToday)
         var added = 0
 
-        // New-source bootstrap: a source with nothing cached may take a few
-        // articles OUTSIDE the daily cap — otherwise a source added on a day
-        // whose intake is already spent shows an empty tag until tomorrow.
-        //
-        // Keyed by name because an Article names its source, so "has this
-        // source cached anything?" is a name-level question. Names are not
-        // unique — subscription is deduplicated by URL everywhere it happens —
-        // so two sources can land on one key, and the two of them then share a
-        // single ration rather than trapping on the way in (#23).
+        // Rationed by name, because an Article names its Source: "has this
+        // Source cached anything?" is a name-level question, and two Sources
+        // under one name — names are not unique, subscription is deduplicated
+        // by URL everywhere it happens — cannot be told apart by it. Taking the
+        // names as a set is what says they share one ration (#23).
         let cachedSourceNames = Set(existing.map(\.sourceName))
-        var bootstrap: [String: Int] = Dictionary(
-            sources
-                .filter { !cachedSourceNames.contains($0.name) }
-                .map { ($0.name, newSourceAllowance) },
-            uniquingKeysWith: { ration, _ in ration }
+        let newSourceNames = Set(sources.map(\.name)).subtracting(cachedSourceNames)
+        var bootstrap = Dictionary(
+            uniqueKeysWithValues: newSourceNames.map { ($0, newSourceAllowance) }
         )
 
         // Pool candidates across all feeds, newest first, so the cap keeps the

--- a/Tests/UnitTests/FeedSyncTests.swift
+++ b/Tests/UnitTests/FeedSyncTests.swift
@@ -28,10 +28,16 @@ final class FeedStub: URLProtocol, @unchecked Sendable {
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
+        // A path nobody registered fails the request rather than serving an
+        // empty feed: a setup mistake should not read as a source with no news.
+        guard let body = Self.bodies[request.url?.path ?? ""] else {
+            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+            return
+        }
         let response = HTTPURLResponse(url: request.url!, statusCode: 200,
                                        httpVersion: nil, headerFields: nil)!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: Self.bodies[request.url?.path ?? ""] ?? Data())
+        client?.urlProtocol(self, didLoad: body)
         client?.urlProtocolDidFinishLoading(self)
     }
 
@@ -167,14 +173,20 @@ struct FeedSyncTests {
         #expect(added == FeedSyncService.newSourceAllowance)
     }
 
+    /// A Source with articles cached takes what is left of the day's intake and
+    /// no more. Two syncs, because a cap with nothing left to give returns 0
+    /// whether or not the feed was ever read — the first take is what proves
+    /// the cap is doing the refusing and the stub is doing the serving.
     @Test("a Source that already has articles cached is held to the daily cap")
-    func cappedSourceGetsNothingMore() async throws {
+    func cappedSourceTakesOnlyWhatTheDayHasLeft() async throws {
         let context = try makeContext()
         source(named: "AI Weekly", path: "/a.xml", items: 10, in: context)
-        cache(FeedSyncService.dailyIntakeLimit, sourceName: "AI Weekly", in: context)
+        cache(FeedSyncService.dailyIntakeLimit - 4, sourceName: "AI Weekly", in: context)
 
-        let added = await sync(context)
+        let firstTake = await sync(context)
+        let secondTake = await sync(context)
 
-        #expect(added == 0)
+        #expect(firstTake == 4, "four of the day's thirty were unspent, and the feed had ten to offer")
+        #expect(secondTake == 0, "the day is spent now, and a cached Source has no bootstrap to fall back on")
     }
 }

--- a/Tests/UnitTests/FeedSyncTests.swift
+++ b/Tests/UnitTests/FeedSyncTests.swift
@@ -1,0 +1,180 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import TechPulse
+
+// Source names are not unique. Subscription is deduplicated by URL everywhere
+// it happens — `SeedData` and `PackSourceOffer` both — so an imported Pack can
+// offer a Source whose name matches one the reader already has under a
+// different URL. The new-Source bootstrap ration was held in a dictionary keyed
+// by name and built with a duplicate-intolerant initializer, so the first sync
+// with nothing cached for either of them trapped (#23). Syncing is how a Source
+// acquires articles, so the condition could not clear itself.
+
+/// Serves feeds for `feeds.test` only, so nothing else a parallel test does is
+/// affected. Same technique as `ArxivStub` in `ResponseLimitTests`, and for the
+/// same reason: `FeedSyncService` has no session to inject, and adding one
+/// would be production surface bought for a test.
+final class FeedStub: URLProtocol, @unchecked Sendable {
+    /// Body per URL path. Written on the main actor before the fetch is awaited
+    /// and read on `URLSession`'s queue after — a happens-before the
+    /// `.serialized` suite keeps true by never letting two tests overlap on it.
+    nonisolated(unsafe) static var bodies: [String: Data] = [:]
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "feeds.test"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        let response = HTTPURLResponse(url: request.url!, statusCode: 200,
+                                       httpVersion: nil, headerFields: nil)!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Self.bodies[request.url?.path ?? ""] ?? Data())
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
+@MainActor
+@Suite("Feed sync", .serialized)
+struct FeedSyncTests {
+
+    private static let sharedContainer: ModelContainer = {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        return try! ModelContainer(
+            for: FeedSource.self, Article.self, Concept.self,
+            LearningEvent.self, ConceptLink.self, ConceptDependency.self,
+            SemanticLink.self, InstalledPack.self,
+            configurations: config
+        )
+    }()
+
+    private func makeContext() throws -> ModelContext {
+        let context = Self.sharedContainer.mainContext
+        for source in try context.fetch(FetchDescriptor<FeedSource>()) { context.delete(source) }
+        for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
+        try context.save()
+        FeedStub.bodies = [:]
+        return context
+    }
+
+    /// A Source whose feed is served by `FeedStub` under `path`, carrying
+    /// `items` entries with guids unique to that path.
+    @discardableResult
+    private func source(named name: String, path: String, items: Int,
+                        in context: ModelContext) -> FeedSource {
+        let source = FeedSource(name: name,
+                                url: URL(string: "https://feeds.test\(path)")!,
+                                category: "LLMs")
+        context.insert(source)
+        FeedStub.bodies[path] = feed(items: items, guidPrefix: path)
+        return source
+    }
+
+    private func feed(items: Int, guidPrefix: String) -> Data {
+        let entries = (0..<items).map { index in
+            """
+              <item>
+                <title>Item \(index)</title>
+                <link>https://example.com\(guidPrefix)/\(index)</link>
+                <guid>\(guidPrefix)-\(index)</guid>
+                <description>Body text \(index).</description>
+                <pubDate>Mon, 06 Jul 2026 08:3\(index % 10):00 GMT</pubDate>
+              </item>
+            """
+        }.joined(separator: "\n")
+        return Data("""
+        <?xml version="1.0"?>
+        <rss version="2.0"><channel>
+        \(entries)
+        </channel></rss>
+        """.utf8)
+    }
+
+    /// Articles already cached today, which is what spends the daily intake cap.
+    private func cache(_ count: Int, sourceName: String, in context: ModelContext) {
+        for index in 0..<count {
+            context.insert(Article(guid: "cached-\(sourceName)-\(index)",
+                                   title: "Cached \(index)",
+                                   content: "Body",
+                                   publishedAt: .now,
+                                   sourceName: sourceName))
+        }
+        try? context.save()
+    }
+
+    private func sync(_ context: ModelContext) async -> Int {
+        URLProtocol.registerClass(FeedStub.self)
+        defer { URLProtocol.unregisterClass(FeedStub.self) }
+        return await FeedSyncService.syncAll(context: context)
+    }
+
+    @Test("two Sources sharing a name, neither with anything cached, sync instead of trapping")
+    func collidingNamesOnAColdSync() async throws {
+        let context = try makeContext()
+        source(named: "AI Weekly", path: "/a.xml", items: 6, in: context)
+        source(named: "AI Weekly", path: "/b.xml", items: 6, in: context)
+
+        let added = await sync(context)
+
+        #expect(added == 12)
+        #expect(try context.fetch(FetchDescriptor<Article>()).count == 12)
+    }
+
+    /// The other half of the window: once articles exist under the shared name,
+    /// both Sources are filtered out of the bootstrap map and the sync has to
+    /// keep working.
+    @Test("the same pair syncs again once articles exist under that name")
+    func collidingNamesOnceCached() async throws {
+        let context = try makeContext()
+        source(named: "AI Weekly", path: "/a.xml", items: 6, in: context)
+        source(named: "AI Weekly", path: "/b.xml", items: 6, in: context)
+        cache(2, sourceName: "AI Weekly", in: context)
+
+        let added = await sync(context)
+
+        #expect(added == 12)
+    }
+
+    /// The accepted trade: colliding Sources share one ration rather than
+    /// getting one each. With the day's intake already spent, the shared ration
+    /// is all that can come in.
+    @Test("colliding Sources share a single bootstrap ration")
+    func collidingNamesShareTheRation() async throws {
+        let context = try makeContext()
+        source(named: "AI Weekly", path: "/a.xml", items: 6, in: context)
+        source(named: "AI Weekly", path: "/b.xml", items: 6, in: context)
+        cache(FeedSyncService.dailyIntakeLimit, sourceName: "Something Else", in: context)
+
+        let added = await sync(context)
+
+        #expect(added == FeedSyncService.newSourceAllowance)
+    }
+
+    /// The behaviour the bootstrap exists for: a Source added on a day whose
+    /// intake is already spent still shows something rather than an empty tag.
+    @Test("a Source with nothing cached is bootstrapped past a spent daily cap")
+    func bootstrapSurvivesASpentCap() async throws {
+        let context = try makeContext()
+        source(named: "AI Weekly", path: "/a.xml", items: 10, in: context)
+        cache(FeedSyncService.dailyIntakeLimit, sourceName: "Something Else", in: context)
+
+        let added = await sync(context)
+
+        #expect(added == FeedSyncService.newSourceAllowance)
+    }
+
+    @Test("a Source that already has articles cached is held to the daily cap")
+    func cappedSourceGetsNothingMore() async throws {
+        let context = try makeContext()
+        source(named: "AI Weekly", path: "/a.xml", items: 10, in: context)
+        cache(FeedSyncService.dailyIntakeLimit, sourceName: "AI Weekly", in: context)
+
+        let added = await sync(context)
+
+        #expect(added == 0)
+    }
+}


### PR DESCRIPTION
Closes #23.

## The defect

`FeedSyncService.syncAll` built its new-Source bootstrap map with `Dictionary(uniqueKeysWithValues:)`, keyed by Source **name**. Names are not unique — subscription is deduplicated by URL everywhere it happens, `SeedData` and `PackSourceOffer` both — so an imported Pack can offer a Source whose name matches one the reader already has under a different URL. With nothing cached for either of them, both survived the filter and the sync trapped.

Self-sustaining once hit: syncing is how a Source acquires the articles that would close the window, so the reader had to disable one Source in Settings to recover.

Reproduced red before the fix: `Fatal error: Duplicate values for key: 'AI Weekly'`.

## The fix

The key stays the name. An `Article` names its Source, so "has this Source cached anything?" is a name-level question, and re-keying by URL cannot tell which of two same-named Sources owns the cached articles. The names become a `Set` before they are rationed, so two Sources under one name share a single ration — the outcome #23 called acceptable, said structurally rather than tie-broken by a `uniquingKeysWith:` closure between two identical constants. A `Set` cannot collide, so there is nothing left to tolerate.

The allowance is now named `newSourceAllowance`, beside the caps it sits with, and `dailyIntakeLimit` is readable by the tests that pin it — the precedent `ResponseLimit.maxBytes` set in #28.

Nothing else about intake, the daily cap, or per-feed limits changes.

## Tests

`Tests/UnitTests/FeedSyncTests.swift` — five tests driving the real `syncAll` over an in-memory store, with the feeds served by a `FeedStub` `URLProtocol` on `feeds.test` (the `ArxivStub` technique from `ResponseLimitTests`, and for the same reason: `FeedSyncService` has no session to inject).

- the colliding pair syncs cold, where `main` traps
- and again once articles exist under that name
- the shared ration is 5 rather than 10
- a genuinely new Source is still bootstrapped past a spent daily cap
- a cached Source takes only what the day has left — four of thirty against a ten-item feed, then zero on a spent day

Every one of the five fails if the stub misfires; checked by unregistering it and watching them all go red, so none of them is green for the wrong reason. Full unit suite: 265 tests in 28 suites, passing.

## Reviewed

`/code-review` over `main...HEAD`, both axes. Two findings acted on in 2677c5a: the cap test broke out of the candidate loop before looking at one, so it asserted the cap without watching it work; and the `uniquingKeysWith:` closure read as "keep the first" when the rule is "one ration per name".

Not acted on: `FeedStub` duplicates `ArxivStub`, and `ByoKeyTests` carries a third `URLProtocol` stub. A shared host-parameterised stub would carry all three, but that rewrites two test files unrelated to this bug.

## Out of scope, per the issue

How `PackSourceOffer` matches suggestions (by URL, deliberately), making Source names unique, and reworking how an `Article` references its Source — the deeper issue underneath this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6k9KkbUUZKopxq69UJaCA