### PR TITLE
De-duplication merges what a reader would call a duplicate, at a threshold that was measured (#41)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,80 @@
 
 ---
 
+## 2026-08-21 — The de-duplication threshold is measured rather than guessed (#41)
+
+**Built**
+- **`ConceptIndex.sameIdeaDistance` is 0.50, calibrated.** It was 0.25, and
+  0.25 admitted nothing: not a plural (`world model` ~ `world models`, 0.449),
+  and not "LLM" ≈ "Large Language Models" (1.26), the pair
+  `findOrCreateConcept`'s doc comment advertised from the day it was written.
+  Matching by meaning was doing nothing matching by name did not already do,
+  above the old 500-Concept ceiling and below it. The new number comes from
+  every pair of the 120 Concept names the two built-in Packs contain — 7,140 of
+  them — measured against restatements of those same names, and the table lives
+  beside the constant rather than in a commit message.
+- **Spelling is folded before meaning is asked**, reusing `ConceptMatch.fold` —
+  the fold Explain has used since ADR-0007. One band cannot be reached by any
+  threshold: a plural of a *one-word* name (`Benchmarks` ~ `Benchmark`, 0.67;
+  `Guardrails` ~ `Guardrail`, 0.75) sits among the distinct pairs, because one
+  word of a one-word name is the whole of its meaning. Spelling has those for
+  nothing, and ADR-0007 had already left "widening dedupe" as a decision for
+  someone with measurements. ADR-0010 takes it.
+- **`HotTopics.candidates` folds too.** It asks the same question with the same
+  constant, and without the fold it could offer "Benchmarks" to a map holding
+  "Benchmark" — a chip that adds nothing when tapped, because `adopt` goes
+  through `findOrCreateConcept` and merges straight back.
+
+**What the measurement said**
+
+Splitting the restatements by which half has to catch them is what set the
+number. What is left for the distance:
+
+| what is left for the distance to merge | measured |
+| --- | --- |
+| "&" spelled "and": `Identity & Access Management` | 0.24–0.30 |
+| one letter of spelling: `Defence`, `Modelling`, `Quantisation` | 0.33–0.38 |
+| an article in front: `The Transformer Architecture` | 0.392 |
+| **nothing the fold does not already have** | **0.39–0.62** |
+| closest two distinct names ship: `Vision Language Models` ~ `Reasoning Models` | 0.620 |
+| `Batch Normalization` ~ `Layer Normalization` | 0.635 |
+| `Supervised Learning` ~ `Unsupervised Learning` | 0.691 |
+
+The ticket had five pairs and guessed the gap was 0.45–0.63; over 7,140 pairs
+nothing distinct is below 0.620, and the fold takes everything between 0.39 and
+0.57 — plurals and separators — whatever their distance. So 0.50 goes in the
+middle of what is genuinely left: 0.11 above the widest restatement the distance
+carries, 0.12 below the closest distinct pair. The first draft of this was 0.55,
+which is the middle of the stretch with nothing measured in it at all; the
+review pointed out that every restatement between 0.39 and 0.57 is one the fold
+already has, so the extra 0.05 bought nothing measured and spent it on the side
+where being wrong takes a reader's Mastery and history rather than their
+tidiness.
+
+**Verified** 409 unit tests, four new and one rewritten; the full suite passes,
+and the four UI journeys with it. The tests over the real embedding are the
+calibration kept runnable rather than written down twice:
+`builtinPacksHoldNoPairInsideTheThreshold` measures every pair of names both
+built-in Packs contain, on both halves of the match, so a Pack that adds a name
+0.45 from one already there fails the suite instead of losing a reader's history
+in the field; `realEmbeddingMergesRestatements` runs seventeen restatements
+through `findOrCreateConcept` with the model that ships;
+`theCalibrationTheThresholdCameFrom` pins the band and the limits; and
+`realEmbeddingStillOffersWhatIsGenuinelyNew` covers the direction the widening
+could have cost something — rising terms against the whole flagship Pack, still
+offered. The tests that inject vectors decide nothing about where the threshold
+sits: they are about what the index does — no ceiling, a Concept created part
+way through a pass matchable by the end of it, which thread waits — and three of
+their fixtures were renamed off "World Model" ~ "World Models" and "LLM" ~
+"Large Language Models" so that neither the fold nor a documented impossibility
+is standing in for the path they exist to test.
+
+**What is still not caught, stated where the constant is** An abbreviation:
+`rag` ~ `retrieval augmented generation` is 1.32, further apart than two
+unrelated Concepts, so no threshold on a sentence embedding can have it. And one
+letter inside a one-word name — `Quantisation` merges at 0.377, but
+`Tokenisation` is 0.578 and folds differently.
+
 ## 2026-08-21 — Embedding a large map is no longer the Feed's problem (#42)
 
 **Built**

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,83 @@
 
 ---
 
+## 2026-08-21 — The flagship gains one Source that is ordered by what people thought (#46)
+
+**Built**
+- **One vote-ranked Source**, `r/MachineLearning/top/.rss?t=week`, in the
+  flagship's LLMs cluster. That is the entire feature: no field marks a Source
+  as popularity-ranked, nothing in `HotTopics` changed, and no code path treats
+  it differently from `KDnuggets`. Popularity ordering is a property of the URL
+  the reader subscribed to (ADR-0003), so the 🔥 lane starts reflecting what
+  practitioners are discussing without the app learning that popularity exists.
+- **One, not several.** Every extra reddit.com Source multiplies the throttling
+  #44 had to pace around — they share a host, so they share a queue. r/kaggle
+  is untouched: it serves the Data Science Cluster chronologically, which is a
+  different job.
+- **Added to both lists that carry the flagship's Sources**, at the same index,
+  because `BuiltinPacksTests` pins them in step. The Pack file is what a
+  reader's installed record gets; `SeedData.defaultSources` is what actually
+  reaches an existing install, since `seedIfNeeded` runs on every launch and
+  inserts defaults that are missing. Pack-file-only would have been inert — the
+  Source offer fires when a reader *installs a Pack from the library*, not on
+  the launch-time reinstall a version bump triggers, so a reader who never
+  opens the Pack library would never have been asked.
+- **What that costs, said plainly.** Seeding subscribes rather than offers, so
+  every existing reader gains this Source at next launch without being asked —
+  including a reader on the Security Engineering Pack, and once subscribed the
+  offer is suppressed for good, because `PackSourceOffer.pending` filters URLs
+  already subscribed. That is not new behaviour: all thirteen AI defaults
+  already reach every reader this way, whatever Pack they are on. It is the
+  pre-existing update path being used for what it was built for, and it sits
+  awkwardly beside the offer sheet's own promise that nothing is subscribed
+  until you say so. Worth revisiting as its own issue rather than settled here.
+- **`PackMigration.builtinPackVersion` 1 → 2**, which is the live lever
+  (`KnowledgePack.packVersion` has been historical since Packs became data), so
+  launch reinstalls the built-in Pack and the record's suggestions move on with
+  the file.
+- **No new line on the Egress list.** `PRIVACY.md`'s first entry is "the public
+  RSS/Atom feeds of the Sources you enabled" — one more feed URL is not a new
+  kind of traffic, which is the test of whether that list changed.
+
+**Verified** 401 unit tests, 5 new; all four UI journeys pass. Three of the new
+tests fail against the previous Pack file. The parity test between the compiled
+defaults and the Pack file passes unchanged, which is what says the two lists
+are still in step.
+
+Also fixed a test written an hour earlier in #45 that was flaky rather than
+wrong: it left one unit of the day's allowance for two Sources, so which of
+them got it depended on the order SwiftData handed the Sources back. It now
+leaves two, one turn each. It had passed on every run until this one.
+
+**What the review changed** Both axes independently found the same two stale
+documents, and they are the reason this entry has a version of the ADR rule in
+it. `ADR-0003`'s second consequence — "a 'top this week' entry carrying a
+six-day-old timestamp loses to same-day arXiv papers by construction" — was
+true of the allocator #45 replaced and false the moment it landed, while
+`SeedData` was busy citing that same ADR as the authority for adding the
+Source. Amended in place, linking forward to ADR-0009. `ROADMAP.md` item 12
+still listed "reserve a minimum slot per enabled source" as open work; ADR-0009
+rejects that option by name, and the fairness half has now shipped as
+round-robin.
+
+The rest were smaller and all in new prose: "feed" used where **Source** was
+meant, inside the very comment citing `CONTEXT.md`'s entry for it; "is six days
+old" where the ADR says "up to six days"; a comment describing the rare branch
+of a guard whose common case is a Source that never had a ration at all; and a
+`SourceQueue` that had been called `Offering`, one word away from
+`PackSourceOffer`, which means something else entirely. The spec axis also
+caught that nothing asserted the Source reached `SeedData.defaultSources` — the
+list that actually delivers it — only the Pack file, with the parity test
+covering the gap by accident.
+
+**Learned** "Add it to the Pack file" was the obvious reading and would have
+shipped nothing. The Pack file is what a Pack *suggests*; the compiled defaults
+are what an existing install actually receives — and the offer path that
+bridges them only runs when a reader installs a Pack by hand. Three mechanisms
+that all look like "the flagship's Sources" from a distance.
+
+---
+
 ## 2026-08-21 — The day is shared between Sources, not won by whoever published this morning (#45)
 
 **Built**
@@ -28,8 +105,8 @@
 - **ADR-0009's decision sentence was wrong and is corrected in place.** It said
   "each Source offers its own newest-first". Sorting a Source's own items by
   date reproduces that ADR's whole fault one level down: a "top this week"
-  entry is six days old, so newest-first *inside* the Source hands over its
-  newest items rather than its best ones, deleting the popularity ordering
+  entry is up to six days old, so newest-first *inside* the Source hands over
+  its newest items rather than its best ones, deleting the popularity ordering
   exactly as the global sort did. The rule that settles it was already in the
   ADR a paragraph earlier — *what a Source is ordered by is part of what you
   subscribed to*. Most feeds are newest-first anyway, which is why the wrong

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,53 @@
 
 ---
 
+## 2026-08-21 — The day is shared between Sources, not won by whoever published this morning (#45)
+
+**Built**
+- **`syncAll` allocates the daily cap round-robin.** Each Source offers its
+  own items and the cap is spent one item per Source per turn, until the day
+  is gone or nobody has anything left. The pooled newest-first sort this
+  replaces let three arXiv feeds offer `perFeedLimit` same-day items each and
+  take the whole day between them; ADR-0009 has the reasoning and the rejected
+  alternatives, including why reserving N slots per Source fails on arithmetic
+  at 13 Sources and a cap of 30.
+- **A Source's own order is left alone, and that is the load-bearing part.**
+  Round-robin decides *how many* items a Source contributes, never *which*.
+  Items are taken from the front of what the Source served, so a chronological
+  feed gives its newest and a vote-ranked one gives its best, and the app never
+  learns which kind it is holding.
+- **ADR-0009's decision sentence was wrong and is corrected in place.** It said
+  "each Source offers its own newest-first". Sorting a Source's own items by
+  date reproduces that ADR's whole fault one level down: a "top this week"
+  entry is six days old, so newest-first *inside* the Source hands over its
+  newest items rather than its best ones, deleting the popularity ordering
+  exactly as the global sort did. The rule that settles it was already in the
+  ADR a paragraph earlier — *what a Source is ordered by is part of what you
+  subscribed to*. Most feeds are newest-first anyway, which is why the wrong
+  sentence read as harmless.
+- **What a turn is, precisely.** A Source that cannot pay — its bootstrap
+  ration spent and the day's allowance gone — is passed over without losing its
+  place, rather than being treated as empty. An item whose guid is already
+  cached is not something offered, so passing over it does not cost that Source
+  its turn. And a Source that has run dry is skipped rather than ending the
+  round, so one short feed cannot leave the day two-thirds unspent.
+
+**Verified** 396 unit tests, 6 new. Four of the six fail against the pooled
+sort: the quiet Source gets nothing beside a firehose, a six-day-old item never
+lands, and the vote-ranked shape hands over its newest two entries instead of
+its first two. The remaining two are guards on the loop rather than on the old
+fault — the cap spent exactly and fully, and a Source running dry not stopping
+the round. The cap is exercised by pre-caching articles to spend the day, never
+by overriding `dailyIntakeLimit`.
+
+**Learned** An ADR can be right about the decision and wrong about the
+mechanism in the same sentence, and the wrong half survives review because it
+describes the common case correctly. "Newest-first per Source" is true of
+twelve of thirteen seeded Sources and fatal to the thirteenth — the one the
+decision was written for.
+
+---
+
 ## 2026-08-21 — One host is asked one thing at a time (#44)
 
 **Built**

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,89 @@
 
 ---
 
+## 2026-08-21 — Embedding a large map is no longer the Feed's problem (#42)
+
+**Built**
+- **`ConceptIndex.prepared`, an async factory that embeds the whole map off
+  the main actor.** The first inexact de-duplication lookup used to embed every
+  Concept name on the map inline — 2.1 s on a 600-Concept map, with no
+  suspension point in it — and `analyzePending` is awaited from `FeedView.task`,
+  so that was the Feed frozen for two seconds on the first Article after launch.
+  The work is unchanged and unconditional: same names, same threshold, no
+  count-based cut-off, because switching de-duplication off above 500 Concepts
+  is exactly what #11 was. Only the thread moved.
+- **`SemanticLinker.embed` is `nonisolated`**, which is what makes that
+  possible. It was main-actor isolated only because its enclosing type is, and
+  `NLEmbedding.vector(for:)` asks for no such thing. The memo and the model
+  moved with it into a lock-guarded `VectorStore` — behind a lock rather than on
+  an actor because both callers are real and neither can become the other:
+  `ConceptIndex.match` is synchronous and has nowhere to await, and the batch
+  must not be on the main actor. The lock is taken per name, so a synchronous
+  caller arriving mid-batch waits for one name, not for six hundred.
+- **`match` stays synchronous**, which is the point of handing back a whole
+  table rather than making callers await a name at a time. `findOrCreateConcept`
+  is called inside loops that already hold the main actor and none of them had
+  to change shape. Names the map did not have — the incoming name of a lookup, a
+  Concept created part way through the pass — are still embedded one at a time,
+  so a twin arriving in the same pass as its original is still merged.
+- **`SemanticLinker.distance` through `vDSP`.** With the embedding moved, what
+  was left on the main actor was the scan: 600 comparisons per lookup, eight
+  lookups per Article, and written out with `zip`/`reduce` that was still a
+  second per Article in a debug build. Same arithmetic, 50× cheaper — measured
+  down to 19 ms. A test pins it against the hand-written form over real Concept
+  names, both for value and for which side of `sameIdeaDistance` each pair
+  lands on, because that threshold was calibrated against the loop as written.
+- **`HotTopics.adopt` and `IntelligenceService.apply` became async**, being the
+  other two places that build an index. The Adopt chip does the same three
+  things in the same order, now inside a `Task`; the offer that drew the chip
+  has already embedded every name, so the pass finds the memo warm.
+- **One spelling for an injected embedder**, `@Sendable (String) -> [Double]?`,
+  across `ConceptIndex`, `SemanticLinker.link`, `HotTopics.candidates` and both
+  `PackInstaller` entry points. Moving one of the six to `@Sendable` and leaving
+  five behind would have left the same idea with two types.
+
+**Verified** 405 unit tests, 4 new; all four UI journeys pass. Measured on a
+600-Concept map with the real embedding: the map costs 1.2 s to embed and holds
+the main actor for 47 ms of it; a full Article's eight lookups cost 19 ms; the
+second index of a batch costs 3.7 ms. `dedupeAtScaleIsPrompt` — which recorded
+this number under an assertion of "under three seconds", a freeze the test was
+happy with — now asserts against what is left on the main actor. Its
+merge-and-create siblings are untouched and pass unchanged.
+
+**What the review changed** The spec axis caught that `HotTopics.candidates`
+has the same shape and is not fixed: it embeds every map name lazily, on the
+main actor, inside a view update, and `FeedView.task` calls it right after
+`analyzePending` — which early-returns when nothing is pending, leaving the memo
+cold. So on a launch with no unanalysed Articles the two seconds are still
+there, one line further down the same `task`. Left for its own issue rather
+than widened into here, but it is the reason this fix is not the whole of the
+freeze.
+
+It also caught that the main-actor test proved the claim at `ConceptIndex`
+rather than at `analyzePending`, which is the seam the criterion names. There
+is now a test at each: the heartbeat is shared, and the one over
+`analyzePending` uses Concept names unique to itself so the launch-long memo is
+cold whatever order the suite runs in. And it read `stall < 0.25` for what it
+was — a quarter-second freeze the test would have licensed. The claim is the
+ratio now, with the absolute bar kept only so a slow machine cannot pass on it.
+
+The standards axis found an absolute in new prose, of the kind `docs/agents/domain.md`
+warns about: "waits a few milliseconds, not the two seconds the batch takes" was
+untrue for the first name of the launch, which holds the lock across the
+several-MB model load. Named rather than glossed. It also read the Adopt button
+right — dropping the chip before `adopt` returned was a behaviour change nobody
+asked for, since a pass that declines to create leaves the offer gone and
+nothing on the map.
+
+**Learned** The fix depends on a language rule, not on anything this code says:
+under Swift 6.0 a `nonisolated async` function runs on the generic executor.
+Adopt `nonisolated(nonsending)` as the default and the batch quietly returns to
+the caller's actor with #42 behind it. That is exactly why the test measures how
+long the main actor went unserved rather than how long the build took — a
+wall-clock test would pass just as happily with the freeze back.
+
+---
+
 ## 2026-08-21 — The flagship gains one Source that is ordered by what people thought (#46)
 
 **Built**

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,42 @@
 
 ---
 
+## 2026-08-22 — Two taps on one chip made two Concepts (#42, found reviewing #50)
+
+**Built**
+- **`HotTopics.adopt` reads the map again on the far side of its suspension.**
+  #42 made `adopt` `async` so the de-duplication index could be built off the
+  main actor. What that added was a window: the pass fetches every Concept,
+  awaits `ConceptIndex.prepared`, and only then matches. The chip that started
+  it is still on screen for the whole of that await — two seconds on a large
+  map — so a second tap starts a second pass that reads the same map, before
+  either has written to it. Both missed, and both created. The synchronous
+  version could not do this.
+- **Reconciled through `insert`, not by rebuilding.** After the await, the store
+  is fetched again and anything that arrived meanwhile is inserted into the
+  index — the same seam a Concept created part way through an analysis batch
+  goes through. Rebuilding the index would have paid the embedding twice.
+  `isNewlyCreated` is asked against the settled map rather than the one the pass
+  started from, so a Concept another pass just created is not set back to unlit
+  by this one.
+- **`ConceptIndex.insert`'s doc comment said this could not happen.** "Never has
+  anything to overwrite: a Concept only reaches `insert` because `match` found
+  nothing" was true of the analysis path and of nothing else. It now names the
+  two callers outside it — a name folding to the empty key, which `match` skips,
+  and this reconciliation.
+
+**Verified** 410 unit tests, one new, and the four UI journeys.
+`concurrentAdoptionsMakeOneConcept` starts two main-actor Tasks against one
+term, which is what two taps make, and expects one Concept. It fails against the
+code as #42 left it, which is the only reason to trust it.
+
+**Learned** `acceptingTwiceIsIdempotent` already existed and covered the same
+sentence in English — accepting twice makes one Concept — while testing the
+sequential case, which was never the one at risk. Making a function `async` does
+not change what its tests assert; it changes which orderings can reach it, and a
+test written before the suspension existed cannot know about the ones it added.
+Found by the spec axis of the review on #50, not by the suite.
+
 ## 2026-08-21 — The de-duplication threshold is measured rather than guessed (#41)
 
 **Built**

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,97 @@
 
 ---
 
+## 2026-08-21 — One host is asked one thing at a time (#44)
+
+**Built**
+- **`syncAll` fetches by host, not by Source.** Sources are grouped by URL
+  host; the groups still run concurrently in one task group, so the cold-sync
+  win survives for every Source alone on its host, and the Sources inside a
+  group go one at a time with `HostPacing.betweenRequests` between them. Host
+  is the unit because host is what the far end counts by — two subreddits are
+  two Sources and one server.
+- **Who actually pays, today.** The seeded set is 13 Sources across 11 hosts,
+  and the three that share one are the arXiv feeds (`cs.AI`, `cs.LG`, `cs.CL`
+  are all `export.arxiv.org`), not the reddit Source this was written for. So a
+  cold sync gains four seconds of deliberate waiting before #46 adds a second
+  reddit.com Source at all — and arXiv, the host that has never throttled us,
+  is the one being paced. That is the cost of not classifying Sources: the rule
+  is about hosts, and it does not get to know which host deserves it.
+- **`HostPacing` is the whole answer to "how fast will you ask a host for
+  things"**, two seconds, in one file, for the reason `ResponseLimit` is one
+  value and not three. It is explicitly not a number that makes throttling go
+  away: ADR-0003 and #43 both watched `r/MachineLearning/top/.rss?t=week`
+  return 429 and then zero bytes on *sequential* fetches two minutes apart,
+  with the descriptive User-Agent set. The agent is unchanged and still sent —
+  the finding is a reason to pace, not a reason to stop identifying ourselves.
+- **The pause separates requests, not list positions.** It is paid only after
+  this host was actually asked something, so the first Source waits for nothing
+  and no sync ends on a wait — and it *is* paid after a request that failed,
+  because a failure is most likely the throttling it exists for, which is the
+  worst moment to ask again at once. A cancelled sleep ends that host's group
+  rather than releasing the rest of it back to back.
+- **The stub answers after a moment now, and remembers when each request was in
+  flight.** `StubTransport` replied inside `startLoading`, which meant it was
+  finished before its caller could issue a second request: two requests fired
+  at once never overlapped, so "these did not overlap" was true of every sync,
+  paced or not, and a pacing test would have been green before the pacing
+  existed. Replies go out on a queue after 50 ms and each request's interval is
+  recorded, so `peakConcurrency(among:)` can be asked of whichever hosts a
+  suite owns. Scoped to named hosts for the same reason `requests(to:)` is —
+  suites run in parallel and the record is shared. Every stubbed response in
+  the process now costs 50 ms; that is the price of the stub being able to
+  express concurrency at all.
+- **ADR-0003's consequence was wider than it claimed and is amended in place.**
+  It recorded a 429 on a *back-to-back* fetch; #43 saw 429 and then zero bytes
+  two minutes apart, which is a different claim about what pacing can buy. The
+  ADR now says both, says the pacing half shipped here, and says the
+  visible-health half is still #14.
+
+**Verified** 390 unit tests, 8 new; three of the four UI journeys pass (see
+below for the fourth). The two pacing tests were run against the
+unpaced `syncAll` and failed there, reporting a peak of 2 requests in flight on
+one host. Non-overlap is not the whole claim — back-to-back requests overlap no
+more than paced ones do — so the same-host test also pins the pause as a lower
+bound on how long that sync takes, which a slow machine cannot fail and a
+deleted `Task.sleep` cannot pass. The stub's own new tests pin both directions:
+two requests issued at once read as overlapping, two issued in sequence do not
+— without the first, the pacing tests would pass against a stub that can only
+ever report 1. The name-collision tests moved their second Source to a second
+host: their subject is a ration keyed by name, and a test should not pay a
+two-second pause to assert something pacing has nothing to do with. The paced
+pair carries the shared name instead, so the #23 shape still runs the paced
+path without a second slow test.
+
+**What the review changed** Both findings were about paying a pause for a
+request that was never sent. `fetchInTurn` slept before every list position
+after the first, so an http Source — turned away by the scheme guard without a
+byte leaving — made the Source behind it wait two seconds for a request no host
+received; the pause is charged per request *asked* now, with a test that fails
+against the old shape. And the stub filed hosts verbatim while `syncAll`
+grouped them lowercased, so a suite writing `Reddit.com` beside `reddit.com`
+would have been told there was no overlap in a pair production had already put
+in one group — a green bought from a disagreement about spelling. The stub keys
+hosts one way now, everywhere it files or is asked about one.
+
+Left standing deliberately: nothing caps a host group's total latency, so the
+three arXiv Sources, if they all hit the 30-second timeout, serialise to ~94
+seconds. Other hosts are unaffected, which is what #44 asked for; a cap on a
+group would be a new decision and belongs with the visible Source health in #14.
+
+The `testCoreJourney` UI journey fails intermittently — `find.exists` then
+`find.label` on the topic-search button, which can vanish between the two. It
+was checked against the unmodified tree and fails there identically, so it is
+not this change; noted rather than fixed, because it is a race in the journey's
+own polling.
+
+**Learned** A test fixture can quietly decide what a test is capable of
+noticing. The stub was correct in everything it claimed about itself and still
+made concurrency unobservable, because answering instantly is not a property
+anyone thought to write down — the honest fix was to give it a duration, not to
+give production a seam.
+
+---
+
 ## 2026-08-20 — Two records answer to one field, and only one is yours (#39)
 
 **Built**

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -100,10 +100,13 @@ journeys, verified in light and dark. Runs on the physical iPhone 14 Pro
       and newest item date — a dead feed (Kaggle's Medium blog died in 2020)
       should be visible, not silent. Consider flagging sources whose newest
       item is > 6 months old.
-    - *Full per-source fairness for the daily cap*: bootstrap (shipped) fixes
-      day one; beyond that, very active feeds (arXiv, TechCrunch) can still
-      crowd quiet weekly feeds out of the newest-first 30. Reserve a minimum
-      slot per enabled source before filling the remainder newest-first.
+    - *Full per-source fairness for the daily cap*: **shipped** (#45), though
+      not as proposed here. Reserving a minimum slot per enabled source was
+      rejected on arithmetic in
+      [ADR-0009](docs/adr/0009-daily-intake-is-shared-between-sources-not-won-by-recency.md)
+      — 13 Sources and a cap of 30 spends 28 of the 30 before the newest-first
+      fill begins, so it is round-robin with a constant bolted on. The cap is
+      allocated round-robin instead, and no per-source constant exists.
     - *Official Kaggle blog RSS watch*: r/kaggle (community Atom feed) is the
       live stand-in today; swap in kaggle.com's own feed if one ever ships
       (retirement mechanism for dead sources already exists in SeedData).

--- a/TechPulse.xcodeproj/project.pbxproj
+++ b/TechPulse.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		6DFDE1DEEC1F113933A40FF6 /* WeeklyLearningIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0794BD56A9EDCCBA857486 /* WeeklyLearningIntent.swift */; };
 		6E32EDEC254288E369341A50 /* KnowledgeEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3217DDB8C0FCEF782C439924 /* KnowledgeEngineTests.swift */; };
 		6F940C83DBFAE7041A7EDE25 /* KnowledgePathEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFB441714355495350731A0 /* KnowledgePathEngine.swift */; };
+		71AF7B8C954EFF67E1C2E2EB /* HostPacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09ABDCB8E0521F01592F86C5 /* HostPacing.swift */; };
 		76300C799239920856F4869D /* IntelligenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB39432F3B7A188E92A963D0 /* IntelligenceService.swift */; };
 		787B5A057456E5A8138E7E57 /* ProgressTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5DEA33C7F76331B8669A39 /* ProgressTabView.swift */; };
 		7B67654466C221D28BE47D9B /* QuizEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B5916628B4441F136B85D0 /* QuizEngine.swift */; };
@@ -165,6 +166,7 @@
 		0544203407045984ECB38FBC /* HotTopicsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HotTopicsTests.swift; sourceTree = "<group>"; };
 		0589963A0AE4B696E53ADA0C /* TechPulseWidgetExtension.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = TechPulseWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		064A64AB8DE1CF19F91AF0D7 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		09ABDCB8E0521F01592F86C5 /* HostPacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostPacing.swift; sourceTree = "<group>"; };
 		0B5DEA33C7F76331B8669A39 /* ProgressTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressTabView.swift; sourceTree = "<group>"; };
 		10B157B00FCB2B06C8B15AA5 /* JourneyLedger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyLedger.swift; sourceTree = "<group>"; };
 		194BEA926165C6E4C7208BAC /* security-engineering.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "security-engineering.json"; sourceTree = "<group>"; };
@@ -435,6 +437,7 @@
 				626B44DBD4047ED09444071D /* FeedSyncService.swift */,
 				FD06BF3A4AAACB4F2DCC8803 /* FullTextService.swift */,
 				9CCF7B94959D93C993B9F598 /* HabitEngine.swift */,
+				09ABDCB8E0521F01592F86C5 /* HostPacing.swift */,
 				A89345C4D2E92AB642D1812C /* HotTopics.swift */,
 				EB39432F3B7A188E92A963D0 /* IntelligenceService.swift */,
 				24CB6AB829AE3904762AA2F3 /* KeychainStore.swift */,
@@ -697,6 +700,7 @@
 				2BA9F64AF3D7DFE40795F23E /* FullMapView.swift in Sources */,
 				E11F2305E68B942DCA1715B4 /* FullTextService.swift in Sources */,
 				46FE11B0203CB7421E08B2DD /* HabitEngine.swift in Sources */,
+				71AF7B8C954EFF67E1C2E2EB /* HostPacing.swift in Sources */,
 				0F072B9F11A0DE69DF17EE7E /* HotTopics.swift in Sources */,
 				3C364DDB6D2D12B536FA8452 /* InstalledPack.swift in Sources */,
 				76300C799239920856F4869D /* IntelligenceService.swift in Sources */,

--- a/TechPulse/Resources/Packs/ai-engineer.json
+++ b/TechPulse/Resources/Packs/ai-engineer.json
@@ -710,6 +710,11 @@
       "url" : "https://huggingface.co/blog/feed.xml"
     },
     {
+      "category" : "LLMs",
+      "name" : "r/MachineLearning (top this week)",
+      "url" : "https://www.reddit.com/r/MachineLearning/top/.rss?t=week"
+    },
+    {
       "category" : "Frontier Labs",
       "name" : "OpenAI News",
       "url" : "https://openai.com/news/rss.xml"

--- a/TechPulse/Services/ConceptIndex.swift
+++ b/TechPulse/Services/ConceptIndex.swift
@@ -203,10 +203,13 @@ struct ConceptIndex {
     /// can match against it.
     mutating func insert(_ concept: Concept) {
         concepts[concept.name.lowercased()] = concept
-        // Overwrites, like the line above it, and never has anything to
-        // overwrite: a Concept only reaches `insert` because `match` found
-        // nothing, and a fold key already taken is exactly what `match` looks
-        // under.
+        // Overwrites, like the line above it. On the analysis path there is
+        // nothing to overwrite — a Concept reaches `insert` because `match`
+        // found nothing, and a fold key already taken is exactly what `match`
+        // looks under. Two cases sit outside that: a name folding to the empty
+        // key, which `match` skips, and `HotTopics.adopt` catching its index up
+        // with Concepts a concurrent pass created. Last writer wins in both,
+        // and neither is consulted under a key it did not put there.
         folded[ConceptMatch.fold(concept.name)] = concept
     }
 

--- a/TechPulse/Services/ConceptIndex.swift
+++ b/TechPulse/Services/ConceptIndex.swift
@@ -24,6 +24,11 @@ struct ConceptIndex {
 
     /// Lowercased name → Concept.
     private(set) var concepts: [String: Concept]
+    /// `ConceptMatch.fold` of each name → Concept: the same table again, keyed
+    /// by spelling folded to case, separators and English plurals. Free to
+    /// build and free to consult, and it catches what the embedding measurably
+    /// cannot — see `sameIdeaDistance`.
+    private var folded: [String: Concept] = [:]
     /// Lowercased name → its meaning. Filled for the whole map by `prepared`,
     /// and one name at a time after that, for names the map did not have when
     /// it was built: the incoming name of a lookup, and Concepts created part
@@ -33,14 +38,63 @@ struct ConceptIndex {
     /// off the main actor — which is the whole of the fix for #42.
     private let vector: @Sendable (String) -> [Double]?
 
-    /// The distance below which two names are the same idea said twice.
+    /// The distance below which two names are the same idea said twice, on the
+    /// scale `SemanticLinker.distance` reports — which is `NLEmbedding`'s own
+    /// scale, over 0…2, and not plain cosine.
     ///
-    /// Conservative on purpose, and unchanged by this work: merging two
-    /// distinct Concepts destroys a reader's history, where a near-duplicate
-    /// only clutters. The ceiling was the bug; the threshold was never it — and
-    /// keeping it meaning what it meant is why the distance is computed on
-    /// `NLEmbedding`'s own scale rather than on plain cosine.
-    static let sameIdeaDistance = 0.25
+    /// ## Where 0.50 comes from
+    ///
+    /// Measured over the 120 Concept names of the two built-in Packs — every
+    /// one of their 7,140 pairs — against restatements of those same names
+    /// written the way an Article's analysis says them (#41). Only the
+    /// restatements `match` has to reach *by meaning* are listed: the ones a
+    /// fold of spelling already has are below, and their distance decides
+    /// nothing.
+    ///
+    /// | what is left for the distance to merge | measured |
+    /// | --- | --- |
+    /// | "&" spelled "and": `Identity & Access Management` | 0.24–0.30 |
+    /// | one letter of spelling: `Defence`, `Modelling`, `Quantisation` | 0.33–0.38 |
+    /// | an article in front: `The Transformer Architecture` | 0.392 |
+    /// | **nothing the fold does not already have** | **0.39–0.62** |
+    /// | closest two distinct names ship: `Vision Language Models` ~ `Reasoning Models` | 0.620 |
+    /// | `Container Security` ~ `Supply Chain Security` | 0.626 |
+    /// | `Batch Normalization` ~ `Layer Normalization` | 0.635 |
+    /// | `Supervised Learning` ~ `Unsupervised Learning` | 0.691 |
+    ///
+    /// 0.50 is the middle of that empty stretch: 0.11 above the widest
+    /// restatement the distance is asked to carry, 0.12 below the closest pair
+    /// of distinct names either built-in Pack contains. Both margins matter,
+    /// and not equally — a merge is destructive, because the incoming Concept
+    /// is never created and Mastery, Lit state and `LearningEvent` history
+    /// consolidate onto whichever name arrived first, where a near-duplicate
+    /// only clutters. `ConceptDedupeTests.builtinPacksHoldNoPairInsideTheThreshold`
+    /// measures the lower margin over every pair rather than restating it.
+    ///
+    /// It replaces 0.25, which admitted nothing at all: not a plural (`world
+    /// model` ~ `world models`, 0.449), and not "LLM" ≈ "Large Language
+    /// Models" (1.26), the pair the doc comment on `findOrCreateConcept`
+    /// advertised from the day it was written. Below the old 500-Concept
+    /// ceiling and above it, matching by meaning was doing nothing matching by
+    /// name did not already do (#11, #41).
+    ///
+    /// ## What it still cannot reach
+    ///
+    /// **Abbreviations**, at any safe threshold: `llm` ~ `large language
+    /// models` is 1.26 and `rag` ~ `retrieval augmented generation` is 1.32 —
+    /// further apart than two unrelated ideas, so widening cannot have them and
+    /// something other than a sentence embedding would be needed.
+    ///
+    /// **A plural of a one-word name**: `Benchmarks` ~ `Benchmark` is 0.67 and
+    /// `Guardrails` ~ `Guardrail` is 0.75, because one word of a one-word name
+    /// is the whole of its meaning. Those land among the distinct pairs, which
+    /// is why `match` folds spelling before it asks about meaning — the fold
+    /// Explain already uses (ADR-0007) has them, and the plurals and separators
+    /// between 0.33 and 0.57 with them, for nothing.
+    ///
+    /// **A one-word name spelled another way**: `Quantisation` merges at 0.377,
+    /// but `Tokenisation` is 0.578 and folds differently, so it does not.
+    static let sameIdeaDistance = 0.50
 
     /// An index that has not embedded anything yet, and will do it on the main
     /// actor when a lookup first needs meaning. Cheap to build and expensive to
@@ -53,6 +107,10 @@ struct ConceptIndex {
          vector: @escaping @Sendable (String) -> [Double]? = SemanticLinker.embed) {
         self.concepts = Dictionary(concepts.map { ($0.name.lowercased(), $0) },
                                    uniquingKeysWith: { first, _ in first })
+        // By name where two Concepts fold together, so which of them answers a
+        // lookup does not depend on what order a fetch happened to return.
+        self.folded = Dictionary(self.concepts.values.map { (ConceptMatch.fold($0.name), $0) },
+                                 uniquingKeysWith: { $0.name <= $1.name ? $0 : $1 })
         self.vector = vector
     }
 
@@ -110,10 +168,22 @@ struct ConceptIndex {
         return meanings
     }
 
-    /// The Concept already standing for this name, by spelling or by meaning.
+    /// The Concept already standing for this name: spelled it, spelled it
+    /// another way, or meaning it.
+    ///
+    /// Spelling is asked first and separately, because the two halves fail in
+    /// different places and neither covers the other. The fold has plurals of
+    /// one-word names, which sit further apart under the embedding than two
+    /// distinct ideas do; the embedding has "&" for "and", and a letter of
+    /// spelling inside a longer name, which no fold reaches. A name spelled
+    /// exactly as an existing Concept still wins over one that merely folds
+    /// the same, so the order here only ever widens what matches.
     mutating func match(_ rawName: String) -> Concept? {
         let name = rawName.lowercased()
         if let exact = concepts[name] { return exact }
+
+        let key = ConceptMatch.fold(rawName)
+        if !key.isEmpty, let spelled = folded[key] { return spelled }
 
         guard let incoming = meaning(of: name), !incoming.isEmpty else { return nil }
         var best: (concept: Concept, distance: Double)?
@@ -133,6 +203,11 @@ struct ConceptIndex {
     /// can match against it.
     mutating func insert(_ concept: Concept) {
         concepts[concept.name.lowercased()] = concept
+        // Overwrites, like the line above it, and never has anything to
+        // overwrite: a Concept only reaches `insert` because `match` found
+        // nothing, and a fold key already taken is exactly what `match` looks
+        // under.
+        folded[ConceptMatch.fold(concept.name)] = concept
     }
 
     private mutating func meaning(of name: String) -> [Double]? {

--- a/TechPulse/Services/ConceptIndex.swift
+++ b/TechPulse/Services/ConceptIndex.swift
@@ -13,14 +13,25 @@ import Foundation
 ///
 /// Held once per pass and passed `inout`, so a Concept created early in a batch
 /// is matchable by the end of it — the same contract the plain dictionary had.
+///
+/// Computing it *once* still costs what it costs: a 600-Concept map is two
+/// seconds of embedding, and paying that on the main actor froze the Feed for
+/// as long (#42). So the map's meanings are computed by `prepared`, away from
+/// the main actor, and `match` stays synchronous over a table that is already
+/// filled in.
 @MainActor
 struct ConceptIndex {
 
     /// Lowercased name → Concept.
     private(set) var concepts: [String: Concept]
-    /// Lowercased name → its meaning, filled the first time it is needed.
+    /// Lowercased name → its meaning. Filled for the whole map by `prepared`,
+    /// and one name at a time after that, for names the map did not have when
+    /// it was built: the incoming name of a lookup, and Concepts created part
+    /// way through a pass.
     private var vectors: [String: [Double]] = [:]
-    private let vector: @MainActor (String) -> [Double]?
+    /// `@Sendable` rather than main-actor isolated, because `prepared` calls it
+    /// off the main actor — which is the whole of the fix for #42.
+    private let vector: @Sendable (String) -> [Double]?
 
     /// The distance below which two names are the same idea said twice.
     ///
@@ -31,11 +42,72 @@ struct ConceptIndex {
     /// `NLEmbedding`'s own scale rather than on plain cosine.
     static let sameIdeaDistance = 0.25
 
+    /// An index that has not embedded anything yet, and will do it on the main
+    /// actor when a lookup first needs meaning. Cheap to build and expensive to
+    /// use: on a 600-Concept map the first inexact lookup pays for the whole map
+    /// at once, which is two seconds with nothing to interrupt it (#42).
+    ///
+    /// Fine for a handful of Concepts, which is what tests hold. Production
+    /// builds through `prepared`.
     init(_ concepts: [Concept],
-         vector: @escaping @MainActor (String) -> [Double]? = SemanticLinker.embed) {
+         vector: @escaping @Sendable (String) -> [Double]? = SemanticLinker.embed) {
         self.concepts = Dictionary(concepts.map { ($0.name.lowercased(), $0) },
                                    uniquingKeysWith: { first, _ in first })
         self.vector = vector
+    }
+
+    /// The same index with the map's meanings already computed — the whole of
+    /// the cost, paid once, off the main actor.
+    ///
+    /// The work itself is unchanged and unconditional: no count-based cut-off
+    /// comes back, because switching de-duplication off above 500 Concepts is
+    /// what #11 was. What changes is the thread. `analyzePending` is awaited
+    /// from `FeedView.task`, so the first Article analysed after launch used to
+    /// hold the Feed for as long as embedding the map took.
+    ///
+    /// Names the map does not have — the incoming name of a lookup, a Concept
+    /// created earlier in this pass — are still embedded by `match`, one at a
+    /// time, on whichever actor is asking. That is a single embedding each, not
+    /// the map's worth.
+    ///
+    /// The map is embedded whether or not the lookups turn out to need it. On
+    /// the analysis path they do: an Article attaches up to eight Concepts and
+    /// one of them missing an exact name is near-certain. On the paths where a
+    /// single exact name might have cost nothing at all — `HotTopics.adopt`,
+    /// Explain — `SemanticLinker.embed` memoises across the launch, and the
+    /// offer that produced the tap has usually embedded the map already.
+    static func prepared(_ concepts: [Concept],
+                         vector: @escaping @Sendable (String) -> [Double]? = SemanticLinker.embed)
+    async -> ConceptIndex {
+        var index = ConceptIndex(concepts, vector: vector)
+        index.vectors = await meanings(of: Array(index.concepts.keys), from: vector)
+        return index
+    }
+
+    /// Embeds a batch of names away from whoever asked.
+    ///
+    /// `nonisolated` and `async`, so calling it from the main actor leaves it:
+    /// under Swift 6.0 a nonisolated async function runs on the generic
+    /// executor, and the caller suspends rather than spinning. Handing back a
+    /// whole table rather than making callers await a name at a time is what
+    /// keeps `match` synchronous.
+    ///
+    /// That is a language rule, not a promise this code makes, and adopting
+    /// `nonisolated(nonsending)` as the default would hand this loop back to
+    /// the caller's actor and #42 with it. The test that would notice is
+    /// `preparingAnIndexDoesNotBlockTheMainActor`, which is why it measures
+    /// main-actor time rather than how long the build took.
+    private nonisolated static func meanings(
+        of names: [String],
+        from vector: @escaping @Sendable (String) -> [Double]?
+    ) async -> [String: [Double]] {
+        var meanings: [String: [Double]] = [:]
+        meanings.reserveCapacity(names.count)
+        // A name the embedding cannot place is remembered as empty rather than
+        // left out, so it is not attempted again for the life of the index —
+        // the same bargain `meaning(of:)` strikes.
+        for name in names { meanings[name] = vector(name) ?? [] }
+        return meanings
     }
 
     /// The Concept already standing for this name, by spelling or by meaning.

--- a/TechPulse/Services/FeedSyncService.swift
+++ b/TechPulse/Services/FeedSyncService.swift
@@ -71,45 +71,73 @@ enum FeedSyncService {
             uniqueKeysWithValues: newSourceNames.map { ($0, newSourceAllowance) }
         )
 
-        // Pool candidates across all feeds, newest first, so the cap keeps the
-        // best (freshest) 30 rather than whichever feed happened to come first.
-        var candidates: [(sourceName: String, item: ParsedFeedItem)] = []
+        // What each Source has to offer, in the order the Source itself put it.
+        // The order is deliberately left alone: what a Source is ordered by is
+        // part of what the reader subscribed to (`CONTEXT.md`, **Source**), so
+        // a vote-ranked feed offers its best first and a chronological one
+        // offers its newest first, and neither is the app's decision to make.
+        var offers: [(sourceName: String, items: [ParsedFeedItem], next: Int)] = []
         for (index, source) in sources.enumerated() {
             guard let data = payloads[index] else { continue }
-            for item in RSSParser.parse(data).prefix(perFeedLimit) {
-                candidates.append((source.name, item))
-            }
+            offers.append((source.name, Array(RSSParser.parse(data).prefix(perFeedLimit)), 0))
             source.lastFetched = .now
         }
-        candidates.sort { ($0.item.publishedAt ?? .now) > ($1.item.publishedAt ?? .now) }
 
-        for candidate in candidates {
-            guard allowance > 0 || !bootstrap.isEmpty else { break }
-            let item = candidate.item
-            guard !item.guid.isEmpty, !knownGuids.contains(item.guid) else { continue }
-            // Charge the bootstrap ration first for brand-new sources; the
-            // shared daily allowance pays for everything else.
-            if let ration = bootstrap[candidate.sourceName] {
-                if ration <= 1 { bootstrap.removeValue(forKey: candidate.sourceName) }
-                else { bootstrap[candidate.sourceName] = ration - 1 }
-            } else if allowance > 0 {
-                allowance -= 1
-            } else {
-                continue
+        // Round-robin: one item per Source per turn, until the cap is spent or
+        // nobody has anything left to give (ADR-0009). The pooled newest-first
+        // sort this replaces let one prolific Source take the whole day —
+        // three arXiv feeds can each offer `perFeedLimit` same-day items — and
+        // in doing so silently made every Source chronological, whatever the
+        // reader actually subscribed to. Round-robin decides *how many* items
+        // a Source contributes and never *which*.
+        var takingTurns = true
+        while takingTurns && (allowance > 0 || !bootstrap.isEmpty) {
+            takingTurns = false
+            for index in offers.indices {
+                guard allowance > 0 || !bootstrap.isEmpty else { break }
+                let sourceName = offers[index].sourceName
+                // A Source whose ration is spent while the day's allowance is
+                // gone cannot take a turn — but it is not exhausted, so its
+                // items keep their place rather than being passed over.
+                let ration = bootstrap[sourceName]
+                guard ration != nil || allowance > 0 else { continue }
+
+                // An article the reader already has is not something offered,
+                // so passing over it does not cost this Source its turn.
+                var offered: ParsedFeedItem?
+                while offers[index].next < offers[index].items.count {
+                    let candidate = offers[index].items[offers[index].next]
+                    offers[index].next += 1
+                    if !candidate.guid.isEmpty, !knownGuids.contains(candidate.guid) {
+                        offered = candidate
+                        break
+                    }
+                }
+                guard let item = offered else { continue }   // nothing left to give
+
+                // Charge the bootstrap ration first for brand-new sources; the
+                // shared daily allowance pays for everything else.
+                if let ration {
+                    if ration <= 1 { bootstrap.removeValue(forKey: sourceName) }
+                    else { bootstrap[sourceName] = ration - 1 }
+                } else {
+                    allowance -= 1
+                }
+                // Some publishers post-date RSS timestamps; clamp so the feed
+                // never shows articles from "the future".
+                let article = Article(
+                    guid: item.guid,
+                    title: item.title.strippingHTML,
+                    content: item.content,
+                    publishedAt: min(item.publishedAt ?? .now, .now),
+                    sourceName: sourceName,
+                    link: item.link.isEmpty ? nil : item.link
+                )
+                context.insert(article)
+                knownGuids.insert(item.guid)
+                added += 1
+                takingTurns = true
             }
-            // Some publishers post-date RSS timestamps; clamp so the feed
-            // never shows articles from "the future".
-            let article = Article(
-                guid: item.guid,
-                title: item.title.strippingHTML,
-                content: item.content,
-                publishedAt: min(item.publishedAt ?? .now, .now),
-                sourceName: candidate.sourceName,
-                link: item.link.isEmpty ? nil : item.link
-            )
-            context.insert(article)
-            knownGuids.insert(item.guid)
-            added += 1
         }
         prune(context: context)
         try? context.save()

--- a/TechPulse/Services/FeedSyncService.swift
+++ b/TechPulse/Services/FeedSyncService.swift
@@ -28,24 +28,25 @@ enum FeedSyncService {
         let enabled = FetchDescriptor<FeedSource>(predicate: #Predicate { $0.isEnabled })
         guard let sources = try? context.fetch(enabled), !sources.isEmpty else { return 0 }
 
-        // Fetch all feeds concurrently (network-bound), then parse/insert on
-        // the main actor. Cuts a cold sync from ~sum to ~max of feed latencies.
+        // Fetch by host: the groups run concurrently, so a cold sync is still
+        // ~max rather than ~sum of feed latencies for the Sources that do not
+        // share a host, and the Sources inside one group go one at a time.
+        // Host is the unit because host is what the far end counts by — two
+        // subreddits are two Sources and one server (#44).
+        //
+        // Hosts are case-insensitive, so `Reddit.com` and `reddit.com` are one
+        // group and not two. A URL with no host is filed under one empty key
+        // with the others of its kind, which is the conservative reading: a
+        // host that cannot be named cannot be shown to be a different one.
         let requests = sources.enumerated().map { (index: $0.offset, url: $0.element.url) }
-        let payloads = await withTaskGroup(of: (Int, Data?).self) { group in
-            for feed in requests {
-                group.addTask {
-                    guard feed.url.scheme == "https" else { return (feed.index, nil) }
-                    var urlRequest = URLRequest(url: feed.url, timeoutInterval: 30)
-                    urlRequest.setValue(userAgent, forHTTPHeaderField: "User-Agent")
-                    guard let (data, response) = try? await URLSession.shared.data(for: urlRequest),
-                          ResponseLimit.accepts(data: data, response: response)
-                    else { return (feed.index, nil) }
-                    return (feed.index, data)
-                }
+        let byHost = Dictionary(grouping: requests) { $0.url.host()?.lowercased() ?? "" }
+        let payloads = await withTaskGroup(of: [(index: Int, data: Data)].self) { group in
+            for hostGroup in byHost.values {
+                group.addTask { await fetchInTurn(hostGroup) }
             }
             var results = [Int: Data]()
-            for await (index, data) in group {
-                if let data { results[index] = data }
+            for await fetched in group {
+                for entry in fetched { results[entry.index] = entry.data }
             }
             return results
         }
@@ -113,6 +114,50 @@ enum FeedSyncService {
         prune(context: context)
         try? context.save()
         return added
+    }
+
+    /// One host's Sources, one request at a time.
+    ///
+    /// The pause separates requests, not list positions: it is paid only after
+    /// this host was actually asked something, so the first Source waits for
+    /// nothing, no sync ends on a wait, and a Source that is never asked — one
+    /// the scheme guard turns away — does not make the Source behind it wait
+    /// for a request the host never received.
+    ///
+    /// It *is* paid after a request that failed. A failure is most likely the
+    /// throttling the pause exists for, and that is the worst moment to ask the
+    /// same host again immediately.
+    private nonisolated static func fetchInTurn(
+        _ sources: [(index: Int, url: URL)]
+    ) async -> [(index: Int, data: Data)] {
+        var fetched = [(index: Int, data: Data)]()
+        var asked = false
+        for source in sources {
+            // Not a request, so not something to pace against: an http Source
+            // is refused here rather than sent (`Egress` leaves over TLS only).
+            guard source.url.scheme == "https" else { continue }
+            if asked {
+                // Cancellation ends the group here rather than releasing the
+                // rest of it back to back, which is the thing being avoided.
+                do { try await Task.sleep(for: HostPacing.betweenRequests) }
+                catch { break }
+            }
+            asked = true
+            if let data = await fetch(source.url) { fetched.append((source.index, data)) }
+        }
+        return fetched
+    }
+
+    /// One request, to a Source `fetchInTurn` has decided is askable. A Source
+    /// that times out, errors, or answers non-2xx or over the response limit
+    /// contributes nothing — and costs the Sources around it nothing either.
+    private nonisolated static func fetch(_ url: URL) async -> Data? {
+        var request = URLRequest(url: url, timeoutInterval: 30)
+        request.setValue(userAgent, forHTTPHeaderField: "User-Agent")
+        guard let (data, response) = try? await URLSession.shared.data(for: request),
+              ResponseLimit.accepts(data: data, response: response)
+        else { return nil }
+        return data
     }
 
     /// Cap the offline cache: read articles older than 60 days are deleted.

--- a/TechPulse/Services/FeedSyncService.swift
+++ b/TechPulse/Services/FeedSyncService.swift
@@ -74,12 +74,13 @@ enum FeedSyncService {
         // What each Source has to offer, in the order the Source itself put it.
         // The order is deliberately left alone: what a Source is ordered by is
         // part of what the reader subscribed to (`CONTEXT.md`, **Source**), so
-        // a vote-ranked feed offers its best first and a chronological one
+        // a vote-ranked Source offers its best first and a chronological one
         // offers its newest first, and neither is the app's decision to make.
-        var offers: [(sourceName: String, items: [ParsedFeedItem], next: Int)] = []
+        var queues: [SourceQueue] = []
         for (index, source) in sources.enumerated() {
             guard let data = payloads[index] else { continue }
-            offers.append((source.name, Array(RSSParser.parse(data).prefix(perFeedLimit)), 0))
+            queues.append(SourceQueue(sourceName: source.name,
+                                      items: Array(RSSParser.parse(data).prefix(perFeedLimit))))
             source.lastFetched = .now
         }
 
@@ -90,30 +91,19 @@ enum FeedSyncService {
         // in doing so silently made every Source chronological, whatever the
         // reader actually subscribed to. Round-robin decides *how many* items
         // a Source contributes and never *which*.
-        var takingTurns = true
-        while takingTurns && (allowance > 0 || !bootstrap.isEmpty) {
-            takingTurns = false
-            for index in offers.indices {
+        var someoneTookATurn = true
+        while someoneTookATurn && (allowance > 0 || !bootstrap.isEmpty) {
+            someoneTookATurn = false
+            for index in queues.indices {
                 guard allowance > 0 || !bootstrap.isEmpty else { break }
-                let sourceName = offers[index].sourceName
-                // A Source whose ration is spent while the day's allowance is
-                // gone cannot take a turn — but it is not exhausted, so its
-                // items keep their place rather than being passed over.
+                let sourceName = queues[index].sourceName
+                // Nothing left to pay with: this Source has no bootstrap ration
+                // — it never had one, or it has spent it — and the day's
+                // allowance is gone. It is not exhausted, though, so its items
+                // keep their place rather than being passed over.
                 let ration = bootstrap[sourceName]
                 guard ration != nil || allowance > 0 else { continue }
-
-                // An article the reader already has is not something offered,
-                // so passing over it does not cost this Source its turn.
-                var offered: ParsedFeedItem?
-                while offers[index].next < offers[index].items.count {
-                    let candidate = offers[index].items[offers[index].next]
-                    offers[index].next += 1
-                    if !candidate.guid.isEmpty, !knownGuids.contains(candidate.guid) {
-                        offered = candidate
-                        break
-                    }
-                }
-                guard let item = offered else { continue }   // nothing left to give
+                guard let item = queues[index].nextUnread(knownGuids) else { continue }
 
                 // Charge the bootstrap ration first for brand-new sources; the
                 // shared daily allowance pays for everything else.
@@ -136,12 +126,44 @@ enum FeedSyncService {
                 context.insert(article)
                 knownGuids.insert(item.guid)
                 added += 1
-                takingTurns = true
+                someoneTookATurn = true
             }
         }
         prune(context: context)
         try? context.save()
         return added
+    }
+
+    /// What one Source has left to give this sync, and how far the round has
+    /// got through it. The order is the Source's own and is never rearranged:
+    /// what a Source is ordered by is part of what the reader subscribed to.
+    ///
+    /// Not an "offer": `PackSourceOffer` already means suggestions put to the
+    /// reader when a Pack installs, which is a different thing entirely.
+    private struct SourceQueue {
+        let sourceName: String
+        let items: [ParsedFeedItem]
+        private var taken = 0
+
+        init(sourceName: String, items: [ParsedFeedItem]) {
+            self.sourceName = sourceName
+            self.items = items
+        }
+
+        /// The next item the reader does not already have, consuming everything
+        /// passed over on the way. An article already cached is not something
+        /// offered, so skipping it must not cost this Source its turn — which
+        /// is why the skipping happens here rather than in the round.
+        mutating func nextUnread(_ knownGuids: Set<String>) -> ParsedFeedItem? {
+            while taken < items.count {
+                let candidate = items[taken]
+                taken += 1
+                if !candidate.guid.isEmpty, !knownGuids.contains(candidate.guid) {
+                    return candidate
+                }
+            }
+            return nil
+        }
     }
 
     /// One host's Sources, one request at a time.

--- a/TechPulse/Services/HostPacing.swift
+++ b/TechPulse/Services/HostPacing.swift
@@ -1,0 +1,22 @@
+/// The one pause between two requests to the same host.
+///
+/// A Source is a subscription and the app is indifferent to what is on the
+/// other end — but the other end is not indifferent to us, and it counts
+/// requests by host rather than by Source. Reddit serves the vote-ranked feeds
+/// the 🔥 lane wants (ADR-0003) and throttles hard: `r/MachineLearning/top/
+/// .rss?t=week` returned HTTP 429 and then zero bytes on plain sequential
+/// fetches two minutes apart while #43 was being written, with the descriptive
+/// User-Agent set. Two Sources on one host fired at once is how one of them
+/// comes back empty and the reader is told nothing.
+///
+/// So this is not a number that makes throttling go away — nothing a client
+/// does can promise that, and the two-minute finding says so. It is the app's
+/// whole answer to *how fast will you ask one host for things*, named once so
+/// that a second fetcher cannot answer it differently, which is the reason
+/// `ResponseLimit` is one value and not three.
+enum HostPacing {
+    /// Two seconds: twice the request-a-second pace hosts commonly ask for, and
+    /// cheap — a sync runs unwatched, and only Sources that share a host wait
+    /// at all.
+    nonisolated static let betweenRequests: Duration = .seconds(2)
+}

--- a/TechPulse/Services/HotTopics.swift
+++ b/TechPulse/Services/HotTopics.swift
@@ -270,6 +270,20 @@ enum HotTopics {
     static func adopt(_ term: HotTerm, context: ModelContext) async -> Concept? {
         let prior = (try? context.fetch(FetchDescriptor<Concept>())) ?? []
         var index = await ConceptIndex.prepared(prior)
+
+        // The map is read again on the other side of that suspension, because
+        // it can move while this pass is embedding. The chip that started this
+        // is still on screen for as long as the embedding takes — two seconds
+        // on a large map — so a second tap is a window a thumb can hit rather
+        // than a theoretical interleaving, and both passes would otherwise
+        // match against a map neither had written to yet and create the
+        // Concept twice. `insert` is the same seam a Concept created part way
+        // through an analysis batch goes through.
+        let settled = (try? context.fetch(FetchDescriptor<Concept>())) ?? prior
+        for concept in settled where !prior.contains(where: { $0 === concept }) {
+            index.insert(concept)
+        }
+
         guard let concept = KnowledgeEngine.findOrCreateConcept(
             named: adoptedName(term), category: adoptedCluster, definition: "",
             context: context, index: &index
@@ -279,8 +293,10 @@ enum HotTopics {
         // an offer puts a dot on the map, it does not claim the reader knows
         // anything. Only for a Concept that was not already there: this may
         // have matched something they have been reading about for weeks, and
-        // `isNewlyCreated` is the check that tells the two apart.
-        if KnowledgeEngine.isNewlyCreated(concept, priorConcepts: prior) {
+        // `isNewlyCreated` is the check that tells the two apart. Against the
+        // settled map, not the one this pass started from: a Concept another
+        // pass just created is not this one's to set back to unlit.
+        if KnowledgeEngine.isNewlyCreated(concept, priorConcepts: settled) {
             concept.masteryLevel = 0
         }
         return concept

--- a/TechPulse/Services/HotTopics.swift
+++ b/TechPulse/Services/HotTopics.swift
@@ -177,9 +177,15 @@ enum HotTopics {
 
     /// Rising terms the reader's map has no room for yet.
     ///
-    /// A term is already on the map if a Concept is named it, contains it as
-    /// words, or *means* it — "retrieval augmentation" against a map holding
+    /// A term is already on the map if a Concept is named it, is spelled it
+    /// once case, separators and plurals are folded away, contains it as words,
+    /// or *means* it — "retrieval augmentation" against a map holding
     /// "RAG" is a duplicate the reader would have to notice was a duplicate.
+    ///
+    /// The fold and the distance are the two halves `ConceptIndex.match` uses,
+    /// and they are here for the same reason they are there: an offer this
+    /// suppresses is one the reader would have tapped to find that adopting it
+    /// merged into a Concept they already had.
     ///
     /// Meaning is judged on vectors rather than by asking for a distance per
     /// pair, and the difference is not academic: `NLEmbedding.distance` embeds
@@ -197,6 +203,11 @@ enum HotTopics {
                            vector: @Sendable (String) -> [Double]? = SemanticLinker.embed)
     -> [HotTerm] {
         let names = concepts.map { $0.name.lowercased() }
+        // Folded once per name rather than once per pair. String work, unlike
+        // the vectors below, so it is not worth making lazy.
+        // Without the empty key, which is what an unnameable Concept folds to
+        // and is not something a term should match.
+        let foldedNames = Set(names.map(ConceptMatch.fold)).subtracting([""])
         // Embedded lazily: a term that matches by name never asks for meaning,
         // and a reader with nothing rising never embeds anything at all.
         var mapVectors: [[Double]]?
@@ -210,9 +221,8 @@ enum HotTopics {
             // suppressing that would silence the extensions this exists to
             // catch. `shares(words:)` is symmetric because collapsing a ranked
             // lane wants it to be; membership does not.
-            let named = names.contains { name in
-                name == text || covers(name, text)
-            }
+            let named = foldedNames.contains(ConceptMatch.fold(text))
+                || names.contains { name in name == text || covers(name, text) }
             if named { continue }
 
             if mapVectors == nil { mapVectors = names.map { vector($0) ?? [] } }

--- a/TechPulse/Services/HotTopics.swift
+++ b/TechPulse/Services/HotTopics.swift
@@ -194,7 +194,7 @@ enum HotTopics {
     /// the reader's, and a Concept that appeared because an article mentioned
     /// something twice is not theirs.
     static func candidates(from terms: [HotTerm], concepts: [Concept],
-                           vector: @MainActor (String) -> [Double]? = SemanticLinker.embed)
+                           vector: @Sendable (String) -> [Double]? = SemanticLinker.embed)
     -> [HotTerm] {
         let names = concepts.map { $0.name.lowercased() }
         // Embedded lazily: a term that matches by name never asks for meaning,
@@ -252,10 +252,14 @@ enum HotTopics {
     /// a term to Anthropic because it got hot, rather than because the reader
     /// asked what it means, would be egress ADR-0006 never enumerated. That is
     /// a decision to take deliberately, not a side effect of this button.
+    ///
+    /// `async` because accepting an offer is a de-duplication pass like any
+    /// other, and building the index over a large map is work for another
+    /// thread (#42) — not for the one the chip was tapped on.
     @discardableResult
-    static func adopt(_ term: HotTerm, context: ModelContext) -> Concept? {
+    static func adopt(_ term: HotTerm, context: ModelContext) async -> Concept? {
         let prior = (try? context.fetch(FetchDescriptor<Concept>())) ?? []
-        var index = ConceptIndex(prior)
+        var index = await ConceptIndex.prepared(prior)
         guard let concept = KnowledgeEngine.findOrCreateConcept(
             named: adoptedName(term), category: adoptedCluster, definition: "",
             context: context, index: &index

--- a/TechPulse/Services/IntelligenceService.swift
+++ b/TechPulse/Services/IntelligenceService.swift
@@ -69,7 +69,7 @@ enum IntelligenceService {
             .map { (name: $0.name, category: $0.category, definition: $0.conceptDefinition) }
         for article in pending {
             let analysis = await analyze(article, vocabulary: vocabulary)
-            apply(analysis, to: article, context: context)
+            await apply(analysis, to: article, context: context)
             try? context.save()
         }
         // Once, for the whole batch: scoring is over every reading at once, so
@@ -104,7 +104,7 @@ enum IntelligenceService {
         let vocabulary = ((try? context.fetch(FetchDescriptor<Concept>())) ?? [])
             .map { (name: $0.name, category: $0.category, definition: $0.conceptDefinition) }
         let analysis = await analyze(article, vocabulary: vocabulary)
-        apply(analysis, to: article, context: context)
+        await apply(analysis, to: article, context: context)
         try? context.save()
         // This article's Concepts changed, so the readings behind the map did.
         KnowledgeEngine.rebuildCoreadLinks(context: context)
@@ -178,7 +178,7 @@ enum IntelligenceService {
         guard let result, !result.definition.isEmpty else { return nil }
 
         let allConcepts = (try? context.fetch(FetchDescriptor<Concept>())) ?? []
-        var index = ConceptIndex(allConcepts)
+        var index = await ConceptIndex.prepared(allConcepts)
 
         // Prefer the model's canonical name, but never let it drift into
         // something unrelated to what the reader actually selected.
@@ -227,7 +227,7 @@ enum IntelligenceService {
         }
 
         let allConcepts = (try? context.fetch(FetchDescriptor<Concept>())) ?? []
-        var index = ConceptIndex(allConcepts)
+        var index = await ConceptIndex.prepared(allConcepts)
         var added: [Concept] = []
         for extracted in items.prefix(5) {
             guard let child = KnowledgeEngine.findOrCreateConcept(
@@ -254,11 +254,15 @@ enum IntelligenceService {
 
     // MARK: Apply results to the store
 
-    private static func apply(_ analysis: ArticleAnalysis, to article: Article, context: ModelContext) {
+    /// `async` for one reason: the index embeds the whole map, and #42 is that
+    /// doing it here — on the main actor, inside the `task` that draws the
+    /// Feed — is a two-second freeze on a large map.
+    private static func apply(_ analysis: ArticleAnalysis, to article: Article,
+                              context: ModelContext) async {
         article.summary = analysis.summary
 
         let allConcepts = (try? context.fetch(FetchDescriptor<Concept>())) ?? []
-        var index = ConceptIndex(allConcepts)
+        var index = await ConceptIndex.prepared(allConcepts)
 
         var attached: [Concept] = []
         for extracted in analysis.concepts where attached.count < 8 {

--- a/TechPulse/Services/KnowledgeEngine.swift
+++ b/TechPulse/Services/KnowledgeEngine.swift
@@ -11,18 +11,17 @@ enum KnowledgeEngine {
 
     // MARK: Concept matching
 
-    /// Case-insensitive match first, then meaning. Creates when new.
+    /// Case-insensitive match first, then folded spelling, then meaning.
+    /// Creates when new.
     ///
     /// This used to say it catches "LLM" ≈ "Large Language Models". Measured,
-    /// the embedding puts that pair at 1.26 against a threshold of 0.25 — five
-    /// times outside it — and a plural at 0.42. So the meaning half currently
-    /// merges nothing a name match would miss, which `ConceptDedupeTests`
-    /// records. Removing the 500-Concept ceiling (#11) makes the scan run at
-    /// any map size; what it admits is a separate question, and answering it
-    /// means calibrating the threshold against real Concept names the way
-    /// `SemanticLinker` calibrated its floor.
+    /// the embedding puts that pair at 1.26 — further apart than two unrelated
+    /// ideas — so no threshold has it and an abbreviation still makes a second
+    /// dot on the map. What the calibration for #41 did buy is everything
+    /// between: a plural, a hyphen, an "&" spelled "and", "-ise" for "-ize".
+    /// `ConceptIndex.sameIdeaDistance` carries the measurements.
     ///
-    /// Both halves live in `ConceptIndex`, which holds each name's meaning
+    /// All three live in `ConceptIndex`, which holds each name's meaning
     /// rather than recomputing it — the cost that used to make this give up
     /// entirely above 500 Concepts (#11). Synchronous, and callable from inside
     /// loops that already hold the main actor, because the index arrives with

--- a/TechPulse/Services/KnowledgeEngine.swift
+++ b/TechPulse/Services/KnowledgeEngine.swift
@@ -24,7 +24,9 @@ enum KnowledgeEngine {
     ///
     /// Both halves live in `ConceptIndex`, which holds each name's meaning
     /// rather than recomputing it — the cost that used to make this give up
-    /// entirely above 500 Concepts (#11).
+    /// entirely above 500 Concepts (#11). Synchronous, and callable from inside
+    /// loops that already hold the main actor, because the index arrives with
+    /// the map's meanings already computed: see `ConceptIndex.prepared` (#42).
     static func findOrCreateConcept(named rawName: String, category: String,
                                     definition: String, context: ModelContext,
                                     index: inout ConceptIndex) -> Concept? {

--- a/TechPulse/Services/PackInstaller.swift
+++ b/TechPulse/Services/PackInstaller.swift
@@ -204,7 +204,7 @@ enum PackInstaller {
     static func install(_ pack: PackFile, origin: PackOrigin,
                         builtinFileName: String? = nil,
                         context: ModelContext,
-                        vector: @MainActor (String) -> [Double]? = SemanticLinker.embed
+                        vector: @Sendable (String) -> [Double]? = SemanticLinker.embed
     ) throws -> InstalledPack {
         try PackValidator.validate(pack)
 
@@ -479,7 +479,7 @@ enum PackInstaller {
     /// the transaction.
     static func rebuildSemanticLinks(
         for concepts: [LinkableConcept], context: ModelContext,
-        vector: @MainActor (String) -> [Double]? = SemanticLinker.embed
+        vector: @Sendable (String) -> [Double]? = SemanticLinker.embed
     ) {
         for link in (try? context.fetch(FetchDescriptor<SemanticLink>())) ?? [] {
             context.delete(link)

--- a/TechPulse/Services/PackMigration.swift
+++ b/TechPulse/Services/PackMigration.swift
@@ -10,7 +10,7 @@ enum PackMigration {
     /// means bumping this, and the reinstall delivers the new Concepts —
     /// the role `KnowledgePack.packVersion` used to play for compiled seeding.
     private static let installedVersionKey = "builtinPackVersion"
-    static let builtinPackVersion = 1
+    static let builtinPackVersion = 2
 
     /// Ensures the reader has an active Pack.
     ///

--- a/TechPulse/Services/SeedData.swift
+++ b/TechPulse/Services/SeedData.swift
@@ -9,6 +9,12 @@ enum SeedData {
         ("arXiv cs.CL", "https://export.arxiv.org/rss/cs.CL", "Research"),
         ("Apple ML Research", "https://machinelearning.apple.com/rss.xml", "Research"),
         ("Hugging Face Blog", "https://huggingface.co/blog/feed.xml", "Open Source"),
+        // Vote-ranked, which is the whole point of it: what a Source is ordered
+        // by is part of what you subscribed to, so community attention reaches
+        // the 🔥 lane without the app ever learning that popularity exists
+        // (ADR-0003, #46). One such Source, not several — they share a host,
+        // so they would share a queue (#44).
+        ("r/MachineLearning (top this week)", "https://www.reddit.com/r/MachineLearning/top/.rss?t=week", "LLMs"),
         ("OpenAI News", "https://openai.com/news/rss.xml", "Frontier Labs"),
         ("Google DeepMind Blog", "https://deepmind.google/blog/rss.xml", "Frontier Labs"),
         ("MIT Technology Review — AI", "https://www.technologyreview.com/topic/artificial-intelligence/feed", "Industry"),

--- a/TechPulse/Services/SemanticLinker.swift
+++ b/TechPulse/Services/SemanticLinker.swift
@@ -63,9 +63,9 @@ enum SemanticLinker {
     /// Concepts reach for each other.
     static let relatednessFloor = 0.5
 
-    /// Loaded once. The embedding is several MB of model; building one per
-    /// install would cost more than the linking does.
-    private static let sharedEmbedding = NLEmbedding.sentenceEmbedding(for: .english)
+    /// The embedding, and everything already computed from it. `nonisolated`,
+    /// so the thread that draws the Feed is not the thread that does this.
+    private nonisolated static let store = VectorStore()
 
     /// The distance between two names, on the scale `NLEmbedding.distance`
     /// reports — which is **not** cosine distance, however it is spelled.
@@ -76,32 +76,32 @@ enum SemanticLinker {
     /// at 0.25 became 0.707 — eight times wider — and merged "supervised
     /// learning" into "unsupervised learning" (#11). Measured against
     /// `NLEmbedding` over 2,211 pairs, this agrees to within 1.2e-06.
+    ///
+    /// Through `vDSP` rather than `zip`/`reduce`, which is the same arithmetic
+    /// and not the same cost: `ConceptIndex.match` runs this once per Concept on
+    /// the map, so a 600-Concept map is 600 of these per lookup and eight
+    /// lookups per Article. Written by hand it was a second of main-actor work
+    /// per Article — the arithmetic left over once #42 moved the embedding off.
     static func distance(between left: [Double], and right: [Double]) -> Double? {
         guard left.count == right.count, !left.isEmpty else { return nil }
-        let dot = zip(left, right).reduce(0) { $0 + $1.0 * $1.1 }
-        let magnitude = (left.reduce(0) { $0 + $1 * $1 }).squareRoot()
-            * (right.reduce(0) { $0 + $1 * $1 }).squareRoot()
+        let dot = vDSP.dot(left, right)
+        let magnitude = vDSP.sumOfSquares(left).squareRoot()
+            * vDSP.sumOfSquares(right).squareRoot()
         guard magnitude > 0 else { return nil }
         return (2 * (1 - dot / magnitude)).squareRoot()
     }
 
-    /// Vectors already computed this launch. A Concept's name does not change,
-    /// and the same names are embedded over and over: de-duplication builds an
-    /// index per Article analysed, so a 600-Concept map was paying 600
-    /// embeddings eight times for one batch (#11).
-    ///
-    /// Bounded by how many distinct names the app has seen — a large map is a
-    /// few megabytes of Double, against ~3.5 ms saved per hit.
-    private static var vectorCache: [String: [Double]] = [:]
-
     /// Where vectors come from unless a caller substitutes its own. Returns
     /// nil on hardware or in a language the embedding has no model for — the
     /// map is poorer, the install still works.
-    static func embed(_ text: String) -> [Double]? {
-        if let known = vectorCache[text] { return known }
-        guard let computed = sharedEmbedding?.vector(for: text) else { return nil }
-        vectorCache[text] = computed
-        return computed
+    ///
+    /// `nonisolated` deliberately. This was main-actor isolated only because
+    /// its enclosing type is, and `NLEmbedding.vector(for:)` asks for no such
+    /// thing — while a caller embedding a whole map wants to be anywhere but
+    /// the thread drawing the Feed. `ConceptIndex.prepared` is that caller, and
+    /// this being callable off the main actor is what lets it be (#42).
+    nonisolated static func embed(_ text: String) -> [Double]? {
+        store.vector(for: text)
     }
 
     /// The Semantic Links for one Pack's Concepts, strongest first.
@@ -110,7 +110,7 @@ enum SemanticLinker {
     /// similarity pass is vectorised and costs a few milliseconds at Pack
     /// scale. The flagship's 68 Concepts link in ~0.4 s.
     static func link(_ concepts: [LinkableConcept],
-                     vector: @MainActor (String) -> [Double]? = embed) -> [SemanticEdge] {
+                     vector: @Sendable (String) -> [Double]? = embed) -> [SemanticEdge] {
         // By name, so a Pack produces the same map however its file is ordered:
         // the mean below is a floating-point sum, and summing in a different
         // order can otherwise nudge a borderline neighbour in or out.
@@ -190,5 +190,52 @@ enum SemanticLinker {
         for vector in vectors { mean = vDSP.add(mean, vector) }
         mean = vDSP.divide(mean, Double(vectors.count))
         return vectors.map { vDSP.subtract($0, mean) }
+    }
+}
+
+/// The sentence embedding, and every vector already computed from it.
+///
+/// Behind a lock rather than on an actor because both of its callers are real
+/// and neither can become the other: `ConceptIndex.match` is synchronous and
+/// has nowhere to await, while `ConceptIndex.prepared` embeds a whole map and
+/// must not run on the main actor. An actor would force the first to change
+/// shape; the main actor would leave the second where #42 found it.
+///
+/// The lock is taken once per name rather than once per batch, so embedding a
+/// 600-Concept map never holds it for more than the one name in flight. What a
+/// synchronous caller arriving mid-batch waits for is that one name — a few
+/// milliseconds — except for the first name of the launch, which is holding
+/// the lock across the several-MB model load as well.
+private final class VectorStore: @unchecked Sendable {
+
+    private let lock = NSLock()
+
+    /// Loaded once, on whichever thread asks first. The embedding is several MB
+    /// of model; building one per call would cost more than the linking does.
+    /// Nil after loading is a real answer — hardware or a language with no
+    /// model — so the attempt is remembered separately from its result.
+    private var embedding: NLEmbedding?
+    private var hasLoaded = false
+
+    /// Vectors already computed this launch. A Concept's name does not change,
+    /// and the same names are embedded over and over: de-duplication builds an
+    /// index per Article analysed, so a 600-Concept map was paying 600
+    /// embeddings eight times for one batch (#11).
+    ///
+    /// Bounded by how many distinct names the app has seen — a large map is a
+    /// few megabytes of Double, against ~3.5 ms saved per hit.
+    private var cache: [String: [Double]] = [:]
+
+    func vector(for text: String) -> [Double]? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let known = cache[text] { return known }
+        if !hasLoaded {
+            embedding = NLEmbedding.sentenceEmbedding(for: .english)
+            hasLoaded = true
+        }
+        guard let computed = embedding?.vector(for: text) else { return nil }
+        cache[text] = computed
+        return computed
     }
 }

--- a/TechPulse/Views/FeedView.swift
+++ b/TechPulse/Views/FeedView.swift
@@ -408,13 +408,22 @@ struct FeedView: View {
             FlowLayout(spacing: 7) {
                 ForEach(candidates, id: \.text) { candidate in
                     Button {
-                        HotTopics.adopt(candidate, context: modelContext)
-                        try? modelContext.save()
-                        // Dropped here rather than by recomputing: `allConcepts`
-                        // is the array this body pass captured, and it does not
-                        // refresh in time — asking again would offer the term
-                        // that was just accepted.
-                        candidates.removeAll { $0.text == candidate.text }
+                        // `adopt` is a de-duplication pass, and #42 moved the
+                        // embedding those cost off the main actor — so the same
+                        // three steps, in the same order, now happen in a Task.
+                        // The offer that drew this chip has already embedded
+                        // every name on the map, so the pass finds the memo warm
+                        // and the chip goes as promptly as it did when this was
+                        // synchronous.
+                        Task {
+                            await HotTopics.adopt(candidate, context: modelContext)
+                            try? modelContext.save()
+                            // Dropped here rather than by recomputing:
+                            // `allConcepts` is the array this body pass
+                            // captured, and it does not refresh in time —
+                            // asking again would offer the term just accepted.
+                            candidates.removeAll { $0.text == candidate.text }
+                        }
                     } label: {
                         // Named as it will be created, so the offer and the dot
                         // it makes are the same words.

--- a/Tests/UnitTests/BuiltinPacksTests.swift
+++ b/Tests/UnitTests/BuiltinPacksTests.swift
@@ -191,4 +191,62 @@ struct BuiltinPacksTests {
         #expect(exported.concepts.map(\.name) == KnowledgePack.concepts.map(\.name))
         #expect(exported.clusterOrder == KnowledgePack.clusterOrder)
     }
+
+    // MARK: - The vote-ranked Source (#46)
+
+    /// ADR-0003 settled that popularity ordering is a property of the URL the
+    /// reader subscribed to, not something the app computes about a platform it
+    /// knows about. So community attention reaches the 🔥 lane by the flagship
+    /// suggesting one vote-ranked feed — and by nothing anywhere in the app
+    /// learning that popularity exists.
+    @Test("the flagship suggests a vote-ranked Source, in the LLMs cluster")
+    func suggestsAVoteRankedSource() throws {
+        let community = try #require(
+            aiEngineer().suggestedSources.first { $0.url.contains("r/MachineLearning") })
+        #expect(community.url == "https://www.reddit.com/r/MachineLearning/top/.rss?t=week")
+        #expect(community.category == "LLMs")
+    }
+
+    /// One, not several. A single popularity signal is enough, and every extra
+    /// reddit.com Source multiplies the throttling #44 had to pace around —
+    /// they share a host, so they share a queue.
+    @Test("exactly one suggested Source is vote-ranked")
+    func onlyOneSourceIsVoteRanked() throws {
+        let sources = try aiEngineer().suggestedSources
+        #expect(sources.count { $0.url.contains("/top/") } == 1)
+        #expect(sources.count { $0.url.contains("reddit.com") } == 2,
+                "the vote-ranked one and r/kaggle, and no more than that on one host")
+    }
+
+    /// The Pack file is what a reader's installed record carries; the compiled
+    /// defaults are what actually reaches an install, because `seedIfNeeded`
+    /// runs on every launch and inserts the ones that are missing. A Source in
+    /// only the first of those two would be suggested to nobody, since the
+    /// offer fires when a reader installs a Pack from the library and not on
+    /// the launch-time reinstall a version bump triggers.
+    @Test("the vote-ranked Source is in the list that actually reaches an install")
+    func voteRankedSourceIsSeeded() {
+        #expect(SeedData.defaultSources.contains {
+            $0.url == "https://www.reddit.com/r/MachineLearning/top/.rss?t=week"
+                && $0.category == "LLMs"
+        })
+    }
+
+    /// r/kaggle serves the Data Science Cluster chronologically, which is a
+    /// different job from the one the vote-ranked Source does.
+    @Test("r/kaggle is left exactly as it was")
+    func kaggleIsUnchanged() throws {
+        let kaggle = try #require(
+            aiEngineer().suggestedSources.first { $0.name.contains("Kaggle") })
+        #expect(kaggle.url == "https://www.reddit.com/r/kaggle/.rss")
+        #expect(kaggle.category == "Data Science")
+    }
+
+    /// A Pack file that changes without the version changing is a Pack file
+    /// that never reaches a reader who installed the version before it.
+    @MainActor
+    @Test("the built-in Pack version moved on with the file")
+    func builtinPackVersionMovedOn() {
+        #expect(PackMigration.builtinPackVersion >= 2)
+    }
 }

--- a/Tests/UnitTests/ConceptDedupeTests.swift
+++ b/Tests/UnitTests/ConceptDedupeTests.swift
@@ -15,7 +15,7 @@ struct ConceptDedupeTests {
 
     /// Names point along their own axis unless they are one of a named pair,
     /// which point the same way — the two ways of saying one idea.
-    private func vectors(sameIdea pair: Set<String> = []) -> @MainActor (String) -> [Double]? {
+    private func vectors(sameIdea pair: Set<String> = []) -> @Sendable (String) -> [Double]? {
         { name in
             var axes = [Double](repeating: 0, count: 128)
             if pair.contains(name) {
@@ -26,6 +26,47 @@ struct ConceptDedupeTests {
             axes[index + 1] = 1
             return axes
         }
+    }
+
+    /// The same names, at roughly what Apple's embedding charges for one.
+    ///
+    /// Injected rather than measured off `NLEmbedding`, because the question
+    /// #42 asks is *which thread waits*, and answering it needs a cost that is
+    /// the same on every machine the suite runs on.
+    private func slowVectors(sameIdea pair: Set<String> = [],
+                             costingEach seconds: TimeInterval = 0.002)
+    -> @Sendable (String) -> [Double]? {
+        let quick = vectors(sameIdea: pair)
+        return { name in
+            Thread.sleep(forTimeInterval: seconds)
+            return quick(name)
+        }
+    }
+
+    /// Runs `work` and reports the longest the main actor went unserved while
+    /// it did — alongside how long it took, which is the number #42 is *not*
+    /// about. The work still costs what it costs; the question is who waits.
+    ///
+    /// The heartbeat is a task on the main actor that does nothing but yield.
+    /// Anything holding the main actor keeps it from being served, and the gap
+    /// it then records is what a reader would have seen as a frozen Feed.
+    private func mainActorStall<T>(during work: () async -> T)
+    async -> (value: T, stall: TimeInterval, elapsed: TimeInterval) {
+        let heartbeat = Task { @MainActor in
+            var longest: TimeInterval = 0
+            var last = Date.now
+            while !Task.isCancelled {
+                await Task.yield()
+                longest = max(longest, Date.now.timeIntervalSince(last))
+                last = .now
+            }
+            return longest
+        }
+        let started = Date.now
+        let value = await work()
+        let elapsed = Date.now.timeIntervalSince(started)
+        heartbeat.cancel()
+        return (value, await heartbeat.value, elapsed)
     }
 
     private func index(_ concepts: [Concept],
@@ -106,6 +147,25 @@ struct ConceptDedupeTests {
         #expect(first === second, "the twin arrived in the same pass that created the original")
     }
 
+    @Test("a Concept created after the map was embedded is matched by the next lookup")
+    func newlyCreatedConceptJoinsAPreparedIndex() async throws {
+        // `prepared` computes the map's meanings up front, and a Concept
+        // created part way through a pass was not on the map when it did. It
+        // still has to be matchable by meaning before the pass ends: analysis
+        // attaches up to eight Concepts from one Article, and the second may
+        // be the first said differently.
+        let context = try context()
+        var index = await ConceptIndex.prepared(
+            [], vector: vectors(sameIdea: ["world model", "world models"]))
+        let first = KnowledgeEngine.findOrCreateConcept(named: "World Model", category: "Foundations",
+                                                        definition: "d", context: context,
+                                                        index: &index)
+        let second = KnowledgeEngine.findOrCreateConcept(named: "World Models", category: "Foundations",
+                                                         definition: "d", context: context,
+                                                         index: &index)
+        #expect(first === second, "the twin arrived after the map's meanings were computed")
+    }
+
     @Test("opposites are not one idea, judged by the embedding the app really uses")
     func realEmbeddingKeepsDistinctConceptsApart() throws {
         // Every other test here injects vectors, so none of them exercises the
@@ -155,15 +215,79 @@ struct ConceptDedupeTests {
 
     // MARK: Cost
 
+    @Test("embedding a large map leaves the main actor free to draw the Feed")
+    func preparingAnIndexDoesNotBlockTheMainActor() async throws {
+        // The work is not the bug and is not reduced: 601 names are still
+        // embedded, and no count-based cut-off dodges them the way #11's
+        // ceiling did. Only the thread changes.
+        let context = try context()
+        var concepts = filler(600, into: context)
+        let existing = Concept(name: "Large Language Models", category: "Foundations",
+                               definition: "d")
+        context.insert(existing)
+        concepts.append(existing)
+
+        let vector = slowVectors(sameIdea: ["large language models", "llm"])
+        let (prepared, stall, elapsed) = await mainActorStall {
+            await ConceptIndex.prepared(concepts, vector: vector)
+        }
+        var index = prepared
+
+        #expect(elapsed > 1, "601 names cost \(elapsed)s — the map was not really embedded")
+        // Measured: 47 ms held, of a 1.2 s build. Before this, the whole 1.2 s
+        // was held, because the whole 1.2 s was on the main actor. The ratio is
+        // the claim; the absolute bar keeps a slow machine from passing on it.
+        #expect(stall < elapsed / 5,
+                "the main actor was held for \(stall)s of the \(elapsed)s build")
+        #expect(stall < 0.25, "the main actor was held for \(stall)s")
+
+        // And what came back is an index, not just a promise of one: the pass
+        // that used to freeze the Feed still merges what it merged before.
+        let matched = KnowledgeEngine.findOrCreateConcept(named: "LLM", category: "Foundations",
+                                                          definition: "d", context: context,
+                                                          index: &index)
+        #expect(matched === existing)
+    }
+
+    @Test("the first analysis after launch does not freeze the Feed")
+    func analyzePendingDoesNotBlockTheMainActor() async throws {
+        // The criterion as #42 words it, at the seam it names: `analyzePending`
+        // is awaited from `FeedView.task`, so main-actor time here is time the
+        // Feed is not drawn. The real embedding, and names unique to this test
+        // so the launch-long memo is cold whichever order the suite runs in.
+        let context = try context()
+        for number in 0..<600 {
+            context.insert(Concept(name: "Analysed Idea \(number)", category: "Foundations",
+                                   definition: "d"))
+        }
+        UITestSupport.seedArticle(context: context)
+
+        let (_, stall, elapsed) = await mainActorStall {
+            await IntelligenceService.analyzePending(context: context)
+        }
+
+        #expect(elapsed > 0.5,
+                "analysis cost \(elapsed)s — 600 Concepts were not really embedded")
+        #expect(stall < elapsed / 5,
+                "the Feed was held for \(stall)s of the \(elapsed)s analysis")
+    }
+
     @Test("de-duplication against a large map does not hold analysis up")
-    func dedupeAtScaleIsPrompt() throws {
+    func dedupeAtScaleIsPrompt() async throws {
         // The real embedding, and the map size the old ceiling refused to work
-        // at. One Article's analysis attaches up to eight Concepts, so this is
-        // eight of these back to back.
+        // at. This is the number #42 was measured from — 2.1 s for 600 names —
+        // and it is now paid off the main actor rather than made smaller.
         let context = try context()
         let concepts = filler(600, into: context)
-        var index = ConceptIndex(concepts)
 
+        let coldStart = Date.now
+        var index = await ConceptIndex.prepared(concepts)
+        let cold = Date.now.timeIntervalSince(coldStart)
+
+        // One Article's analysis attaches up to eight Concepts, so this is
+        // eight lookups back to back. What is left on the main actor is one
+        // embedding of each incoming name and a scan over meanings already in
+        // hand — arithmetic, not the map's worth of model.
         let started = Date.now
         for number in 0..<8 {
             _ = KnowledgeEngine.findOrCreateConcept(named: "Fresh Idea \(number)",
@@ -171,18 +295,21 @@ struct ConceptDedupeTests {
                                                     context: context, index: &index)
         }
         let elapsed = Date.now.timeIntervalSince(started)
-        #expect(elapsed < 3, "eight lookups against 600 Concepts took \(elapsed)s")
+        // Measured: 19 ms, against the 1.2 s the map's own meanings cost. It was
+        // a second of this alone until `SemanticLinker.distance` went through
+        // `vDSP` — 4,800 comparisons per Article is enough to notice.
+        #expect(elapsed < 0.1, "eight lookups against 600 Concepts took \(elapsed)s")
 
         // And the next Article in the same batch builds its own index, which is
         // where the cost used to be paid again in full. A name's meaning does
-        // not change, so the second pass should be arithmetic and nothing else.
-        var second = ConceptIndex(concepts)
+        // not change, so the second build should be arithmetic and nothing else.
         let secondStart = Date.now
+        var second = await ConceptIndex.prepared(concepts)
         _ = KnowledgeEngine.findOrCreateConcept(named: "Another Fresh Idea",
                                                 category: "Foundations", definition: "d",
                                                 context: context, index: &second)
         let secondElapsed = Date.now.timeIntervalSince(secondStart)
-        #expect(secondElapsed < elapsed / 4,
-                "the second index cost \(secondElapsed)s against the first's \(elapsed)s")
+        #expect(secondElapsed < cold / 8,
+                "the second index cost \(secondElapsed)s against the first's \(cold)s")
     }
 }

--- a/Tests/UnitTests/ConceptDedupeTests.swift
+++ b/Tests/UnitTests/ConceptDedupeTests.swift
@@ -87,15 +87,21 @@ struct ConceptDedupeTests {
 
     @Test("a near-duplicate is still merged on a map far past the old cut-off")
     func mergesAboveTheOldCeiling() throws {
+        // The pair used to be "LLM" ~ "Large Language Models", which the model
+        // that ships puts 1.26 apart — further than two unrelated ideas — so
+        // the fixture was asserting a merge the app now says in three places
+        // it cannot make. Two names for one idea that the fold cannot fold
+        // together says what this test is about without the fiction.
         let context = try context()
         var concepts = filler(600, into: context)
-        let existing = Concept(name: "Large Language Models", category: "Foundations",
+        let existing = Concept(name: "World Model", category: "Foundations",
                                definition: "d")
         context.insert(existing)
         concepts.append(existing)
 
-        var index = index(concepts, sameIdea: ["large language models", "llm"])
-        let matched = KnowledgeEngine.findOrCreateConcept(named: "LLM", category: "Foundations",
+        var index = index(concepts, sameIdea: ["world model", "environment simulator"])
+        let matched = KnowledgeEngine.findOrCreateConcept(named: "Environment Simulator",
+                                                          category: "Foundations",
                                                           definition: "d", context: context,
                                                           index: &index)
 
@@ -136,12 +142,16 @@ struct ConceptDedupeTests {
 
     @Test("a Concept created through the index is matched by the next lookup")
     func newlyCreatedConceptJoinsTheIndex() throws {
+        // Named so the two spellings have nothing in common, which is what
+        // keeps this on the path it is about: a twin caught by *meaning*, not
+        // one the spelling fold would have caught whatever the index held.
         let context = try context()
-        var index = index([], sameIdea: ["world model", "world models"])
+        var index = index([], sameIdea: ["world model", "environment simulator"])
         let first = KnowledgeEngine.findOrCreateConcept(named: "World Model", category: "Foundations",
                                                         definition: "d", context: context,
                                                         index: &index)
-        let second = KnowledgeEngine.findOrCreateConcept(named: "World Models", category: "Foundations",
+        let second = KnowledgeEngine.findOrCreateConcept(named: "Environment Simulator",
+                                                         category: "Foundations",
                                                          definition: "d", context: context,
                                                          index: &index)
         #expect(first === second, "the twin arrived in the same pass that created the original")
@@ -156,11 +166,12 @@ struct ConceptDedupeTests {
         // be the first said differently.
         let context = try context()
         var index = await ConceptIndex.prepared(
-            [], vector: vectors(sameIdea: ["world model", "world models"]))
+            [], vector: vectors(sameIdea: ["world model", "environment simulator"]))
         let first = KnowledgeEngine.findOrCreateConcept(named: "World Model", category: "Foundations",
                                                         definition: "d", context: context,
                                                         index: &index)
-        let second = KnowledgeEngine.findOrCreateConcept(named: "World Models", category: "Foundations",
+        let second = KnowledgeEngine.findOrCreateConcept(named: "Environment Simulator",
+                                                         category: "Foundations",
                                                          definition: "d", context: context,
                                                          index: &index)
         #expect(first === second, "the twin arrived after the map's meanings were computed")
@@ -170,9 +181,21 @@ struct ConceptDedupeTests {
     func realEmbeddingKeepsDistinctConceptsApart() throws {
         // Every other test here injects vectors, so none of them exercises the
         // threshold against the model that ships. These pairs are real Concept
-        // names from the flagship Pack and are emphatically not each other.
+        // names from the built-in Packs and are emphatically not each other.
+        //
+        // The first four are the closest distinct pairs the calibration for #41
+        // turned up over all 7,140 pairs of the two built-in Packs — 0.62 to
+        // 0.64, which is what the threshold has to stay under. The rest are
+        // pairs chosen by hand for being the kind of near-miss a merge would
+        // be worst on.
         let context = try context()
-        let pairs = [("Supervised Learning", "Unsupervised Learning"),
+        let pairs = [("Vision Language Models", "Reasoning Models"),
+                     ("Container Security", "Supply Chain Security"),
+                     ("Prompt Engineering", "Detection Engineering"),
+                     ("Data Leakage", "Data Poisoning"),
+                     ("Container Security", "Kubernetes Security"),
+                     ("Prompt Engineering", "Context Engineering"),
+                     ("Supervised Learning", "Unsupervised Learning"),
                      ("Layer Normalization", "Quantization"),
                      ("Batch Normalization", "Layer Normalization"),
                      ("Reinforcement Learning", "Reinforcement Learning from Human Feedback")]
@@ -190,27 +213,139 @@ struct ConceptDedupeTests {
         }
     }
 
-    @Test("the shipped threshold, measured rather than described")
-    func realEmbeddingDistances() throws {
-        // What `sameIdeaDistance` actually admits, on the scale `NLEmbedding`
-        // reports. Recorded as assertions because the file's own doc comment
-        // has advertised "LLM" ≈ "Large Language Models" since it was written,
-        // and the model puts that pair five times outside the threshold.
+    @Test("the threshold sits in the gap the calibration measured")
+    func theCalibrationTheThresholdCameFrom() throws {
+        // Where 0.50 comes from, on the scale `NLEmbedding` reports. Recorded
+        // as assertions rather than as prose because the previous threshold was
+        // prose — 0.25, with a doc comment claiming it merged "LLM" into
+        // "Large Language Models", which the model puts five times outside it.
         func distance(_ left: String, _ right: String) throws -> Double {
-            let a = try #require(SemanticLinker.embed(left))
-            let b = try #require(SemanticLinker.embed(right))
+            let a = try #require(SemanticLinker.embed(left.lowercased()))
+            let b = try #require(SemanticLinker.embed(right.lowercased()))
             return try #require(SemanticLinker.distance(between: a, and: b))
         }
 
-        // Kept apart, and rightly — these are different ideas.
-        #expect(try distance("supervised learning", "unsupervised learning") > ConceptIndex.sameIdeaDistance)
-        #expect(try distance("batch normalization", "layer normalization") > ConceptIndex.sameIdeaDistance)
+        // The band the distance is asked to carry is only the restatements the
+        // fold does not already have, so the widest of those is what the
+        // threshold has to clear — not `Red-Teaming` ~ `Red Teaming` at 0.545,
+        // which merges on spelling whatever the number says.
+        let widestByMeaning = try distance("Transformer Architecture",
+                                           "The Transformer Architecture")       // 0.392
+        let nearestDistinct = try distance("Vision Language Models",
+                                           "Reasoning Models")                   // 0.620
+        #expect(widestByMeaning < ConceptIndex.sameIdeaDistance)
+        #expect(nearestDistinct > ConceptIndex.sameIdeaDistance)
+        // Both margins are real, and the empty stretch between them is where
+        // the line went: nothing the fold does not already have was measured
+        // inside it.
+        #expect(ConceptIndex.sameIdeaDistance - widestByMeaning > 0.1)
+        #expect(nearestDistinct - ConceptIndex.sameIdeaDistance > 0.1)
 
-        // And kept apart, which is the limit worth knowing: at 0.25 the
-        // embedding merges neither a plural nor an abbreviation, so matching by
-        // meaning is doing nothing that matching by name does not already do.
-        #expect(try distance("world model", "world models") > ConceptIndex.sameIdeaDistance)
-        #expect(try distance("llm", "large language models") > ConceptIndex.sameIdeaDistance)
+        // What the distance alone cannot reach, stated rather than implied.
+        //
+        // A plural of a one-word name is a bigger share of that name's meaning
+        // than a plural of a three-word one, so it lands among the distinct
+        // pairs and no threshold can have it. `ConceptMatch.fold` is what
+        // merges these, on spelling.
+        #expect(try distance("Benchmarks", "Benchmark") > ConceptIndex.sameIdeaDistance)
+        #expect(try distance("Guardrails", "Guardrail") > ConceptIndex.sameIdeaDistance)
+        #expect(ConceptMatch.fold("Benchmarks") == ConceptMatch.fold("Benchmark"))
+        #expect(ConceptMatch.fold("Guardrails") == ConceptMatch.fold("Guardrail"))
+
+        // A spelling neither half catches: one letter inside a one-word name
+        // moves it as far as a different idea would, and folding it would be a
+        // guess about English rather than about separators and plurals.
+        #expect(try distance("Tokenization", "Tokenisation") > ConceptIndex.sameIdeaDistance)
+        #expect(ConceptMatch.fold("Tokenization") != ConceptMatch.fold("Tokenisation"))
+
+        // And abbreviations, which are out of reach at any safe threshold:
+        // both of these are further apart than two unrelated ideas, so an
+        // embedding is the wrong instrument for them (#41).
+        #expect(try distance("LLM", "Large Language Models") > 1)
+        #expect(try distance("RAG", "Retrieval Augmented Generation") > 1)
+    }
+
+    @Test("no two names in the built-in Packs are one idea")
+    func builtinPacksHoldNoPairInsideTheThreshold() throws {
+        // The claim the calibration actually makes, over the whole corpus it
+        // was derived from rather than the handful of pairs quoted from it:
+        // 120 Concept names across both built-in Packs, every pair of them, on
+        // both halves of the match. A Pack whose own names merge into each
+        // other would lose a reader's history on the day it was installed.
+        var names: [String] = []
+        var seen: Set<String> = []
+        for builtin in BuiltinPacks.all {
+            for concept in builtin.pack.concepts
+            where seen.insert(concept.name.lowercased()).inserted {
+                names.append(concept.name)
+            }
+        }
+        #expect(names.count > 100, "both built-in Packs should be in this corpus")
+
+        var folded: [String: String] = [:]
+        for name in names {
+            let key = ConceptMatch.fold(name)
+            #expect(folded[key] == nil,
+                    "“\(name)” folds onto “\(folded[key] ?? "")”")
+            folded[key] = name
+        }
+
+        let vectors = try names.map { try #require(SemanticLinker.embed($0.lowercased())) }
+        var nearest = (distance: Double.infinity, pair: ("", ""))
+        for i in names.indices {
+            for j in names.indices where j > i {
+                let measured = try #require(SemanticLinker.distance(between: vectors[i],
+                                                                    and: vectors[j]))
+                if measured < nearest.distance {
+                    nearest = (measured, (names[i], names[j]))
+                }
+            }
+        }
+        // Measured: 0.620, for "Vision Language Models" ~ "Reasoning Models".
+        #expect(nearest.distance > ConceptIndex.sameIdeaDistance,
+                "“\(nearest.pair.0)” ~ “\(nearest.pair.1)” at \(nearest.distance)")
+    }
+
+    @Test("one idea said twice is merged, judged by the embedding the app really uses")
+    func realEmbeddingMergesRestatements() throws {
+        // The other half of #41, and the half that was doing nothing: at 0.25
+        // matching by meaning merged nothing matching by name did not already
+        // merge. Real Concept names from the built-in Packs, against the way an
+        // Article's analysis would have said the same thing.
+        //
+        // Both routes are here on purpose and the test does not say which is
+        // which: what a reader is promised is that a restatement of a Concept
+        // they already have does not become a second dot on their map.
+        let context = try context()
+        let pairs = [("World Models", "World Model"),
+                     ("Vector Databases", "Vector Database"),
+                     ("Reasoning Models", "Reasoning Model"),
+                     ("Identity & Access Management", "Identity and Access Management"),
+                     ("Probability & Statistics", "Probability and Statistics"),
+                     ("Computer-Use Agents", "Computer Use Agents"),
+                     ("Threat Modeling", "Threat Modelling"),
+                     ("Quantization", "Quantisation"),
+                     ("Prompt Injection Defense", "Prompt Injection Defence"),
+                     ("Benchmarks", "Benchmark"),
+                     ("Embeddings", "Embedding"),
+                     ("Guardrails", "Guardrail"),
+                     ("Eval Suites", "Eval Suite"),
+                     ("Fine-Tuning", "Fine Tuning"),
+                     ("Red-Teaming", "Red Teaming"),
+                     ("KV-Cache", "KV Cache"),
+                     ("LLM-as-Judge", "LLM as Judge")]
+
+        for (existingName, incomingName) in pairs {
+            let existing = Concept(name: existingName, category: "Foundations", definition: "d")
+            context.insert(existing)
+            var index = ConceptIndex([existing])
+            let matched = KnowledgeEngine.findOrCreateConcept(named: incomingName,
+                                                              category: "Foundations",
+                                                              definition: "d", context: context,
+                                                              index: &index)
+            #expect(matched === existing,
+                    "“\(incomingName)” became a second dot beside “\(existingName)”")
+        }
     }
 
     // MARK: Cost

--- a/Tests/UnitTests/FeedSyncTests.swift
+++ b/Tests/UnitTests/FeedSyncTests.swift
@@ -356,8 +356,10 @@ struct FeedSyncTests {
         orderedSource(named: "Community", host: Self.otherHost, path: "/top.xml",
                       entries: [("top-0", 6)], in: context)
         // Spend all but two of the day, so recency would have to fight for a
-        // place rather than being handed thirty of them.
-        cache(FeedSyncService.dailyIntakeLimit - 2, sourceName: "Firehose", in: context)
+        // place rather than being handed thirty of them — and leave exactly two,
+        // one turn each, so which Source the store hands back first cannot
+        // decide the outcome.
+        cache(FeedSyncService.dailyIntakeLimit - 3, sourceName: "Firehose", in: context)
         cache(1, sourceName: "Community", in: context)
 
         _ = await sync(context)

--- a/Tests/UnitTests/FeedSyncTests.swift
+++ b/Tests/UnitTests/FeedSyncTests.swift
@@ -81,6 +81,51 @@ struct FeedSyncTests {
         """.utf8)
     }
 
+    /// A feed served in exactly the order given, each entry dated `daysAgo`
+    /// days back. Separating order from date is the whole point: a vote-ranked
+    /// Source lists its best first and its newest wherever it falls, and the
+    /// allocator must not quietly reorder that into a date sort.
+    private func orderedFeed(_ entries: [(guid: String, daysAgo: Int)]) -> Data {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
+        let items = entries.map { entry in
+            let date = formatter.string(from: .now.addingTimeInterval(-Double(entry.daysAgo) * 86_400))
+            return """
+              <item>
+                <title>Item \(entry.guid)</title>
+                <link>https://example.com/\(entry.guid)</link>
+                <guid>\(entry.guid)</guid>
+                <description>Body text.</description>
+                <pubDate>\(date)</pubDate>
+              </item>
+            """
+        }.joined(separator: "\n")
+        return Data("""
+        <?xml version="1.0"?>
+        <rss version="2.0"><channel>
+        \(items)
+        </channel></rss>
+        """.utf8)
+    }
+
+    /// A Source serving `entries` in that order, on its own host so nothing
+    /// here pays for pacing it is not asserting.
+    @discardableResult
+    private func orderedSource(named name: String, host: String, path: String,
+                               entries: [(guid: String, daysAgo: Int)],
+                               in context: ModelContext) -> FeedSource {
+        let url = URL(string: "https://\(host)\(path)")!
+        let source = FeedSource(name: name, url: url, category: "LLMs")
+        context.insert(source)
+        StubTransport.serve(url, body: orderedFeed(entries))
+        return source
+    }
+
+    private func cachedGuids(in context: ModelContext) throws -> Set<String> {
+        Set(try context.fetch(FetchDescriptor<Article>()).map(\.guid))
+    }
+
     /// Articles already cached today, which is what spends the daily intake cap.
     private func cache(_ count: Int, sourceName: String, in context: ModelContext) {
         for index in 0..<count {
@@ -270,5 +315,144 @@ struct FeedSyncTests {
             $0.value(forHTTPHeaderField: "User-Agent") == FeedSyncService.userAgent
         })
         #expect(FeedSyncService.userAgent == "TechPulse/1.0 (iOS offline RSS reader)")
+    }
+
+    // MARK: - The cap is shared, not won by recency (#45, ADR-0009)
+
+    /// The fault ADR-0009 names: the cap was spent newest-first across the
+    /// pooled candidates of every Source, so a Source publishing thirty items
+    /// today took the lot and a quiet one took nothing. Both Sources have an
+    /// article cached, so neither has a bootstrap ration and the day's
+    /// allowance is the only thing paying.
+    @Test("a quiet Source is represented beside one offering far more")
+    func aQuietSourceIsRepresentedBesideAFirehose() async throws {
+        let context = try makeContext()
+        orderedSource(named: "Firehose", host: Self.host, path: "/firehose.xml",
+                      entries: (0..<30).map { (guid: "firehose-\($0)", daysAgo: 0) },
+                      in: context)
+        orderedSource(named: "Quiet", host: Self.otherHost, path: "/quiet.xml",
+                      entries: [("quiet-0", 5), ("quiet-1", 6)], in: context)
+        cache(1, sourceName: "Firehose", in: context)
+        cache(1, sourceName: "Quiet", in: context)
+
+        let added = await sync(context)
+
+        let guids = try cachedGuids(in: context)
+        #expect(guids.isSuperset(of: ["quiet-0", "quiet-1"]),
+                "the quiet Source's items are five and six days old and still arrive")
+        #expect(added == FeedSyncService.dailyIntakeLimit - 2,
+                "the two already cached today are what the day had spent")
+    }
+
+    /// The half of the same claim that #46 rests on: an item's age is not what
+    /// decides whether it is taken, so a Source whose best is days old is not
+    /// outranked by whatever was published this morning.
+    @Test("an older item reaches the cache beside a Source full of same-day ones")
+    func anOlderItemReachesTheCacheBesideSameDayItems() async throws {
+        let context = try makeContext()
+        orderedSource(named: "Firehose", host: Self.host, path: "/firehose.xml",
+                      entries: (0..<30).map { (guid: "firehose-\($0)", daysAgo: 0) },
+                      in: context)
+        orderedSource(named: "Community", host: Self.otherHost, path: "/top.xml",
+                      entries: [("top-0", 6)], in: context)
+        // Spend all but two of the day, so recency would have to fight for a
+        // place rather than being handed thirty of them.
+        cache(FeedSyncService.dailyIntakeLimit - 2, sourceName: "Firehose", in: context)
+        cache(1, sourceName: "Community", in: context)
+
+        _ = await sync(context)
+
+        #expect(try cachedGuids(in: context).contains("top-0"),
+                "a six-day-old item takes its turn like any other")
+    }
+
+    /// Round-robin governs *how many* items a Source contributes and never
+    /// *which*: a Source's own ordering is part of what the reader subscribed
+    /// to (`CONTEXT.md`, **Source**). Re-sorting each Source's own items
+    /// newest-first would reproduce ADR-0009's fault inside every Source and
+    /// delete the only property a vote-ranked Source has.
+    @Test("a Source's own ordering decides which of its items are taken")
+    func aSourcesOwnOrderingDecidesWhichItemsAreTaken() async throws {
+        let context = try makeContext()
+        // A vote-ranked shape: best first, and the newest entry last.
+        orderedSource(named: "Community", host: Self.host, path: "/top.xml",
+                      entries: [("top-best", 6), ("top-second", 5),
+                                ("top-third", 3), ("top-newest", 0)],
+                      in: context)
+        cache(FeedSyncService.dailyIntakeLimit - 2, sourceName: "Community", in: context)
+
+        let added = await sync(context)
+
+        #expect(added == 2)
+        #expect(try cachedGuids(in: context).isSuperset(of: ["top-best", "top-second"]),
+                "the two the Source put first, not the two published most recently")
+        #expect(try cachedGuids(in: context).isDisjoint(with: ["top-newest"]),
+                "the newest entry is last in this feed, and that is the Source's business")
+    }
+
+    @Test("the cap is spent exactly, and fully, when the Sources have items to give")
+    func theCapIsSpentExactlyAndFully() async throws {
+        let context = try makeContext()
+        for (index, host) in [Self.host, Self.otherHost].enumerated() {
+            orderedSource(named: "Source \(index)", host: host, path: "/s\(index).xml",
+                          entries: (0..<20).map { (guid: "s\(index)-\($0)", daysAgo: 0) },
+                          in: context)
+            cache(1, sourceName: "Source \(index)", in: context)
+        }
+
+        let added = await sync(context)
+
+        #expect(added == FeedSyncService.dailyIntakeLimit - 2)
+        #expect(try context.fetch(FetchDescriptor<Article>()).count
+                == FeedSyncService.dailyIntakeLimit)
+    }
+
+    /// A Source with nothing left to offer is skipped rather than spending a
+    /// turn, so the cap is not left partly unspent because one Source ran dry.
+    /// A guard on the loop's stopping rule rather than on the old fault: the
+    /// obvious round-robin, which stops as soon as any Source empties, leaves
+    /// the day two-thirds unspent here.
+    @Test("a Source that runs out does not hold back the cap")
+    func anExhaustedSourceDoesNotHoldBackTheCap() async throws {
+        let context = try makeContext()
+        orderedSource(named: "Deep", host: Self.host, path: "/deep.xml",
+                      entries: (0..<30).map { (guid: "deep-\($0)", daysAgo: 0) },
+                      in: context)
+        orderedSource(named: "Shallow", host: Self.otherHost, path: "/shallow.xml",
+                      entries: [("shallow-0", 1)], in: context)
+        cache(1, sourceName: "Deep", in: context)
+        cache(1, sourceName: "Shallow", in: context)
+
+        let added = await sync(context)
+
+        #expect(added == FeedSyncService.dailyIntakeLimit - 2,
+                "Shallow had one to give; Deep spent the rest of the day rather than leaving it")
+        #expect(try cachedGuids(in: context).contains("shallow-0"))
+    }
+
+    /// An item the reader already has is not an item offered, so passing over
+    /// it must not cost that Source its turn.
+    @Test("a Source whose newest items are already cached still contributes")
+    func alreadyCachedItemsDoNotCostATurn() async throws {
+        let context = try makeContext()
+        orderedSource(named: "Repeat", host: Self.host, path: "/repeat.xml",
+                      entries: [("repeat-0", 2), ("repeat-1", 1), ("repeat-2", 0)],
+                      in: context)
+        orderedSource(named: "Other", host: Self.otherHost, path: "/other.xml",
+                      entries: (0..<10).map { (guid: "other-\($0)", daysAgo: 0) },
+                      in: context)
+        cache(1, sourceName: "Repeat", in: context)
+        cache(1, sourceName: "Other", in: context)
+        // The first two of Repeat's three are already here.
+        for guid in ["repeat-0", "repeat-1"] {
+            context.insert(Article(guid: guid, title: "Seen", content: "Body",
+                                   publishedAt: .now, sourceName: "Repeat"))
+        }
+        try context.save()
+
+        _ = await sync(context)
+
+        #expect(try cachedGuids(in: context).contains("repeat-2"),
+                "two known guids were passed over without spending the Source's turn")
     }
 }

--- a/Tests/UnitTests/FeedSyncTests.swift
+++ b/Tests/UnitTests/FeedSyncTests.swift
@@ -10,6 +10,16 @@ import SwiftData
 // by name and built with a duplicate-intolerant initializer, so the first sync
 // with nothing cached for either of them trapped (#23). Syncing is how a Source
 // acquires articles, so the condition could not clear itself.
+//
+// Two Sources are also two requests, and the host on the other end counts them
+// together. `syncAll` fired every Source at once and discarded failures
+// silently, so a second reddit.com Source produced a simultaneous request, one
+// of the two came back throttled, and nobody was told (#44). Non-overlap is
+// asserted through `StubTransport.peakConcurrency(among:)` rather than through
+// timings, because that claim is about overlap and not about duration — but
+// non-overlap alone is also true of two requests fired back to back, which is
+// the hammering, so the pause itself is pinned as a lower bound on how long a
+// same-host sync takes.
 
 @MainActor
 @Suite("Feed sync", .serialized)
@@ -25,6 +35,7 @@ struct FeedSyncTests {
         for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
         try context.save()
         StubTransport.stopServing(host: Self.host)
+        StubTransport.stopServing(host: Self.otherHost)
         return context
     }
 
@@ -33,12 +44,17 @@ struct FeedSyncTests {
     /// is registered process-wide and the host is what keeps it narrow.
     private static let host = "feeds.test"
 
+    /// A second host, for the half of the pacing that must *not* happen — and
+    /// for every test whose subject is not pacing, which puts its Sources here
+    /// rather than paying `HostPacing.betweenRequests` to assert something else.
+    private static let otherHost = "other.feeds.test"
+
     /// A Source whose feed `StubTransport` serves under `path`, carrying
     /// `items` entries with guids unique to that path.
     @discardableResult
-    private func source(named name: String, path: String, items: Int,
-                        in context: ModelContext) -> FeedSource {
-        let url = URL(string: "https://\(Self.host)\(path)")!
+    private func source(named name: String, host: String = Self.host, path: String,
+                        items: Int, in context: ModelContext) -> FeedSource {
+        let url = URL(string: "https://\(host)\(path)")!
         let source = FeedSource(name: name, url: url, category: "LLMs")
         context.insert(source)
         StubTransport.serve(url, body: feed(items: items, guidPrefix: path))
@@ -87,7 +103,7 @@ struct FeedSyncTests {
     func collidingNamesOnAColdSync() async throws {
         let context = try makeContext()
         source(named: "AI Weekly", path: "/a.xml", items: 6, in: context)
-        source(named: "AI Weekly", path: "/b.xml", items: 6, in: context)
+        source(named: "AI Weekly", host: Self.otherHost, path: "/b.xml", items: 6, in: context)
 
         let added = await sync(context)
 
@@ -102,7 +118,7 @@ struct FeedSyncTests {
     func collidingNamesOnceCached() async throws {
         let context = try makeContext()
         source(named: "AI Weekly", path: "/a.xml", items: 6, in: context)
-        source(named: "AI Weekly", path: "/b.xml", items: 6, in: context)
+        source(named: "AI Weekly", host: Self.otherHost, path: "/b.xml", items: 6, in: context)
         cache(2, sourceName: "AI Weekly", in: context)
 
         let added = await sync(context)
@@ -117,7 +133,7 @@ struct FeedSyncTests {
     func collidingNamesShareTheRation() async throws {
         let context = try makeContext()
         source(named: "AI Weekly", path: "/a.xml", items: 6, in: context)
-        source(named: "AI Weekly", path: "/b.xml", items: 6, in: context)
+        source(named: "AI Weekly", host: Self.otherHost, path: "/b.xml", items: 6, in: context)
         cache(FeedSyncService.dailyIntakeLimit, sourceName: "Something Else", in: context)
 
         let added = await sync(context)
@@ -153,5 +169,106 @@ struct FeedSyncTests {
 
         #expect(firstTake == 4, "four of the day's thirty were unspent, and the feed had ten to offer")
         #expect(secondTake == 0, "the day is spent now, and a cached Source has no bootstrap to fall back on")
+    }
+
+    // MARK: - One host at a time (#44)
+
+    /// The two share a name as well as a host, so the #23 shape — one bootstrap
+    /// ration between them — runs through the paced path here rather than
+    /// costing a second two-second test of its own.
+    @Test("two Sources on one host are never in flight together, and both contribute")
+    func sameHostSourcesAreFetchedOneAtATime() async throws {
+        let context = try makeContext()
+        source(named: "AI Weekly", path: "/a.xml", items: 3, in: context)
+        source(named: "AI Weekly", path: "/b.xml", items: 3, in: context)
+
+        let started = ContinuousClock.now
+        let added = await sync(context)
+        let elapsed = ContinuousClock.now - started
+
+        #expect(StubTransport.peakConcurrency(among: Self.host) == 1)
+        // A lower bound, so a slow machine cannot fail it — and back-to-back
+        // requests, which overlap no more than paced ones do, cannot pass it.
+        #expect(elapsed >= HostPacing.betweenRequests,
+                "the second request waits rather than following straight on")
+        #expect(StubTransport.requests(to: Self.host).count == 2,
+                "paced is not skipped — both Sources were still asked")
+        #expect(added == 6, "and both were heard")
+    }
+
+    /// The cold-sync latency win #44 was careful to keep. Without this, pacing
+    /// every Source would pass the test above just as well.
+    @Test("Sources on different hosts are still fetched at the same time")
+    func differentHostsAreFetchedConcurrently() async throws {
+        let context = try makeContext()
+        source(named: "First", path: "/a.xml", items: 3, in: context)
+        source(named: "Second", host: Self.otherHost, path: "/b.xml", items: 3, in: context)
+
+        let added = await sync(context)
+
+        #expect(StubTransport.peakConcurrency(among: Self.host, Self.otherHost) == 2,
+                "two hosts share no pacing, so the two requests overlap")
+        #expect(added == 6)
+    }
+
+    /// The failure the pacing exists for, from the other end: a host that
+    /// refuses one request. It must cost that Source and nothing else — and the
+    /// Source that follows it in the same group must still be asked.
+    @Test("a throttled Source contributes nothing and costs the others nothing")
+    func aThrottledSourceIsIsolated() async throws {
+        let context = try makeContext()
+        let throttled = URL(string: "https://\(Self.host)/throttled.xml")!
+        context.insert(FeedSource(name: "Throttled", url: throttled, category: "LLMs"))
+        StubTransport.serve(throttled, status: 429, body: "")
+        source(named: "Healthy", path: "/healthy.xml", items: 4, in: context)
+        source(named: "Elsewhere", host: Self.otherHost, path: "/c.xml", items: 2, in: context)
+
+        let added = await sync(context)
+
+        #expect(added == 6, "the 429 contributed nothing and stopped nothing")
+        let names = Set(try context.fetch(FetchDescriptor<Article>()).map(\.sourceName))
+        #expect(names == ["Healthy", "Elsewhere"])
+        #expect(StubTransport.peakConcurrency(among: Self.host) == 1,
+                "a refusal is the worst moment to ask the host again at once")
+    }
+
+    /// The pause is paid between *requests*, so a Source that is never asked
+    /// cannot spend it. Without this, an http Source ahead of an https one on
+    /// the same host bought the reader a two-second wait for a request no host
+    /// ever received.
+    @Test("a Source that is never asked does not make the next one wait")
+    func aSourceThatIsNeverAskedCostsNoPause() async throws {
+        let context = try makeContext()
+        let insecure = URL(string: "http://\(Self.host)/insecure.xml")!
+        context.insert(FeedSource(name: "Insecure", url: insecure, category: "LLMs"))
+        source(named: "Healthy", path: "/healthy.xml", items: 3, in: context)
+
+        let started = ContinuousClock.now
+        let added = await sync(context)
+        let elapsed = ContinuousClock.now - started
+
+        #expect(added == 3, "the http Source was refused, the https one was read")
+        #expect(StubTransport.requests(to: Self.host).count == 1,
+                "the refused Source was never sent, so there was nothing to pace against")
+        #expect(elapsed < HostPacing.betweenRequests)
+    }
+
+    /// ADR-0003's finding is that the descriptive agent does not stop reddit
+    /// throttling — which is a reason to pace, not a reason to stop sending it.
+    @Test("every Source is still asked with the descriptive User-Agent")
+    func theUserAgentIsUnchanged() async throws {
+        let context = try makeContext()
+        source(named: "First", path: "/a.xml", items: 1, in: context)
+        source(named: "Second", host: Self.otherHost, path: "/b.xml", items: 1, in: context)
+
+        _ = await sync(context)
+
+        let sent = StubTransport.requests(to: Self.host)
+            + StubTransport.requests(to: Self.otherHost)
+        #expect(sent.count == 2)
+        #expect(sent.allSatisfy {
+            $0.value(forHTTPHeaderField: "User-Agent") == FeedSyncService.userAgent
+        })
+        #expect(FeedSyncService.userAgent == "TechPulse/1.0 (iOS offline RSS reader)")
     }
 }

--- a/Tests/UnitTests/HotCandidateTests.swift
+++ b/Tests/UnitTests/HotCandidateTests.swift
@@ -51,6 +51,40 @@ struct HotCandidateTests {
         #expect(candidates.isEmpty, "matched on name, ignoring case")
     }
 
+    @Test("a rising term the map does not mean is offered, judged by the real embedding")
+    func realEmbeddingStillOffersWhatIsGenuinelyNew() throws {
+        // The other side of the threshold move (#41). Widening it from 0.25 to
+        // 0.50 suppresses more, and what it must not suppress is the growth
+        // this feature exists to catch. The real embedding, against the whole
+        // flagship Pack, over terms of the kind a reader's Sources actually
+        // raise — including "small models", which at 0.570 against `Small
+        // Language Models` is the nearest any of them came.
+        let concepts = try BuiltinPacks.load(BuiltinPacks.aiEngineerFileName).concepts
+            .map { concept($0.name, cluster: $0.cluster) }
+        let rising = ["attention sinks", "test-time compute", "mixture of experts",
+                      "small models"]
+
+        for text in rising {
+            let candidates = HotTopics.candidates(from: [term(text)], concepts: concepts)
+            #expect(candidates.map(\.text) == [text],
+                    "“\(text)” was taken for something the map already has")
+        }
+    }
+
+    @Test("a term the map already has, spelled another way, is not offered")
+    func foldedSpellingIsNotOffered() {
+        // The plural of a one-word name is further from it, under the
+        // embedding, than two distinct ideas are (#41) — so this is the fold's
+        // to catch, here as in `ConceptIndex.match`. Offering it would put a
+        // chip in front of the reader that adds nothing when tapped: adopting
+        // it merges straight back into the Concept they already have.
+        let candidates = HotTopics.candidates(from: [term("benchmarks"), term("kv cache")],
+                                              concepts: [concept("Benchmark"),
+                                                         concept("KV-Cache")],
+                                              vector: strangers)
+        #expect(candidates.isEmpty, "matched on spelling, ignoring plural and hyphen")
+    }
+
     @Test("a term the map already has inside a longer Concept name is not offered")
     func containedNameIsNotOffered() {
         let candidates = HotTopics.candidates(from: [term("world model")],

--- a/Tests/UnitTests/HotCandidateTests.swift
+++ b/Tests/UnitTests/HotCandidateTests.swift
@@ -181,6 +181,29 @@ struct HotCandidateTests {
         #expect(try context.fetch(FetchDescriptor<Concept>()).count == 1)
     }
 
+    @Test("accepting the same candidate twice at once does not make two Concepts")
+    func concurrentAdoptionsMakeOneConcept() async throws {
+        // Two taps on one chip. `adopt` became `async` in #42, and the chip
+        // stays on screen across the suspension — up to the two seconds
+        // embedding a large map costs — so this is a window a thumb can hit,
+        // not a theoretical interleaving. Both passes read the map before
+        // either has written to it, so both used to miss and both create.
+        let context = try context()
+        let rising = term("world model")
+        // Two main-actor tasks, which is what two taps make: the Feed's chip
+        // starts an unstructured `Task` and `adopt` is `@MainActor`.
+        let first = Task { @MainActor in
+            _ = await HotTopics.adopt(rising, context: context)
+        }
+        let second = Task { @MainActor in
+            _ = await HotTopics.adopt(rising, context: context)
+        }
+        await first.value
+        await second.value
+
+        #expect(try context.fetch(FetchDescriptor<Concept>()).count == 1)
+    }
+
     @Test("accepting something already on the map does not undo what was learned")
     func acceptingDoesNotResetMastery() async throws {
         // The offer should not have shown this, but a name can also arrive by

--- a/Tests/UnitTests/HotCandidateTests.swift
+++ b/Tests/UnitTests/HotCandidateTests.swift
@@ -72,12 +72,12 @@ struct HotCandidateTests {
     }
 
     @Test("an adopted Concept lands outside the Pack's own Clusters")
-    func adoptedConceptDoesNotInflatePackProgress() throws {
+    func adoptedConceptDoesNotInflatePackProgress() async throws {
         // `WordSelection.cluster` is deliberately outside `clusterOrder` so
         // looked-up words can never inflate "2 of 13 lit". A term the reader
         // accepted is the same kind of arrival.
         let context = try context()
-        let adopted = try #require(HotTopics.adopt(term("world model"), context: context))
+        let adopted = try #require(await HotTopics.adopt(term("world model"), context: context))
         let pack = try BuiltinPacks.aiEngineer()
         #expect(!pack.clusterOrder.contains(adopted.category),
                 "“\(adopted.category)” is one of the Pack's own Clusters")
@@ -129,9 +129,9 @@ struct HotCandidateTests {
     // MARK: Accepting one
 
     @Test("an accepted candidate joins the map as an ordinary Concept")
-    func acceptedCandidateJoinsTheMap() throws {
+    func acceptedCandidateJoinsTheMap() async throws {
         let context = try context()
-        let adopted = try #require(HotTopics.adopt(term("world model"), context: context))
+        let adopted = try #require(await HotTopics.adopt(term("world model"), context: context))
 
         #expect(adopted.name == "World Model", "named as a reader would write it")
         #expect(adopted.category == HotTopics.adoptedCluster)
@@ -140,15 +140,15 @@ struct HotCandidateTests {
     }
 
     @Test("accepting the same candidate twice does not make two Concepts")
-    func acceptingTwiceIsIdempotent() throws {
+    func acceptingTwiceIsIdempotent() async throws {
         let context = try context()
-        _ = HotTopics.adopt(term("world model"), context: context)
-        _ = HotTopics.adopt(term("world model"), context: context)
+        _ = await HotTopics.adopt(term("world model"), context: context)
+        _ = await HotTopics.adopt(term("world model"), context: context)
         #expect(try context.fetch(FetchDescriptor<Concept>()).count == 1)
     }
 
     @Test("accepting something already on the map does not undo what was learned")
-    func acceptingDoesNotResetMastery() throws {
+    func acceptingDoesNotResetMastery() async throws {
         // The offer should not have shown this, but a name can also arrive by
         // another route — and setting a Concept back to unlit because a
         // headline mentioned it would take away the reader's own progress.
@@ -158,7 +158,7 @@ struct HotCandidateTests {
         context.insert(known)
         try context.save()
 
-        let adopted = try #require(HotTopics.adopt(term("world model"), context: context))
+        let adopted = try #require(await HotTopics.adopt(term("world model"), context: context))
         #expect(adopted.masteryLevel == 0.7)
         #expect(adopted.category == "Foundations", "and it keeps the Cluster it was in")
         #expect(try context.fetch(FetchDescriptor<Concept>()).count == 1)
@@ -183,9 +183,9 @@ struct HotCandidateTests {
     }
 
     @Test("an accepted candidate stops being offered")
-    func acceptedCandidateLeavesTheOffer() throws {
+    func acceptedCandidateLeavesTheOffer() async throws {
         let context = try context()
-        _ = HotTopics.adopt(term("world model"), context: context)
+        _ = await HotTopics.adopt(term("world model"), context: context)
         let concepts = try context.fetch(FetchDescriptor<Concept>())
         #expect(HotTopics.candidates(from: [term("world model")], concepts: concepts,
                                      vector: strangers).isEmpty)

--- a/Tests/UnitTests/SemanticLinkerTests.swift
+++ b/Tests/UnitTests/SemanticLinkerTests.swift
@@ -15,7 +15,7 @@ struct SemanticLinkerTests {
 
     /// A vector source built from explicit coordinates, so "related" is
     /// something the test decides rather than something it hopes for.
-    private func vectors(_ table: [String: [Double]]) -> @MainActor @Sendable (String) -> [Double]? {
+    private func vectors(_ table: [String: [Double]]) -> @Sendable (String) -> [Double]? {
         { table[$0] }
     }
 
@@ -28,6 +28,43 @@ struct SemanticLinkerTests {
 
     private func pairs(_ edges: [SemanticEdge]) -> Set<String> {
         Set(edges.map { "\($0.conceptA)~\($0.conceptB)" })
+    }
+
+    // MARK: - The distance the threshold was calibrated against
+
+    @Test("the vectorised distance is the distance that was written out")
+    func vectorisedDistanceMatchesTheWrittenOne() throws {
+        // `distance` went through `vDSP` for speed (#42) — a scan over a large
+        // map runs it once per Concept, and written by hand that was a second
+        // of main-actor arithmetic per Article. Summing in a different order is
+        // allowed to differ in the last bits. It is not allowed to move a pair
+        // across `ConceptIndex.sameIdeaDistance`, which was calibrated against
+        // the arithmetic as it was written, on real Concept names.
+        func written(_ left: [Double], _ right: [Double]) -> Double {
+            let dot = zip(left, right).reduce(0) { $0 + $1.0 * $1.1 }
+            let magnitude = (left.reduce(0) { $0 + $1 * $1 }).squareRoot()
+                * (right.reduce(0) { $0 + $1 * $1 }).squareRoot()
+            return (2 * (1 - dot / magnitude)).squareRoot()
+        }
+
+        let names = ["supervised learning", "unsupervised learning",
+                     "batch normalization", "layer normalization", "quantization",
+                     "llm", "large language models", "world model", "world models",
+                     "attention", "retrieval", "reinforcement learning"]
+        let vectors = try names.map { try #require(SemanticLinker.embed($0)) }
+
+        for i in vectors.indices {
+            for j in vectors.indices where j > i {
+                let measured = try #require(SemanticLinker.distance(between: vectors[i],
+                                                                    and: vectors[j]))
+                let byHand = written(vectors[i], vectors[j])
+                #expect(abs(measured - byHand) < 1e-12,
+                        "“\(names[i])” vs “\(names[j])”: \(measured) against \(byHand)")
+                #expect((measured < ConceptIndex.sameIdeaDistance)
+                            == (byHand < ConceptIndex.sameIdeaDistance),
+                        "“\(names[i])” vs “\(names[j])” changed sides of the threshold")
+            }
+        }
     }
 
     // MARK: - The graph rules

--- a/Tests/UnitTests/StubTransport.swift
+++ b/Tests/UnitTests/StubTransport.swift
@@ -25,6 +25,12 @@ import Synchronization
 ///   global registration is counted — a suite tidying up must not disarm one
 ///   still running, and Swift Testing runs suites in parallel even when each
 ///   is `.serialized` within itself.
+/// - **It answers after a moment, and records when each request was in
+///   flight.** A stub that replied inside `startLoading` was finished before
+///   its caller could issue a second request, so two requests fired at once
+///   never overlapped and "these did not overlap" was true of every sync,
+///   paced or not. `peakConcurrency(among:)` is what lets #44's per-host
+///   pacing be asserted rather than assumed.
 ///
 /// Two installation modes, because the fetchers differ: `session()` for a
 /// caller that takes a `URLSession` (`AnthropicClient`), and
@@ -34,7 +40,15 @@ import Synchronization
 /// builds its own session leaves a test to do. ADR-0006 declined a seam of its
 /// own — the `IntelligenceService` call site — but said nothing about these
 /// two, and this is not the place to decide it.
-final class StubTransport: URLProtocol {
+///
+/// `@unchecked Sendable` because the reply is delivered off the loading thread
+/// rather than inside `startLoading`. Every piece of mutable state this class
+/// declares, shared and per-instance alike, is behind a `Mutex`. What it does
+/// *not* own is `client` and `request`, inherited from a `URLProtocol` that
+/// predates the checker: `request` is a value fixed before loading starts, and
+/// answering `client` from wherever the reply is ready is the arrangement every
+/// asynchronous `URLProtocol` has always had.
+final class StubTransport: URLProtocol, @unchecked Sendable {
 
     /// What a stubbed URL answers with.
     private struct Reply {
@@ -52,14 +66,29 @@ final class StubTransport: URLProtocol {
 
         init?(_ url: URL?) {
             guard let host = url?.host(), let path = url?.path() else { return nil }
-            self.host = host
+            self.host = StubTransport.key(host)
             self.path = path
         }
+    }
+
+    /// One request's time in flight. Kept as an interval rather than a running
+    /// count so that "were these two ever in flight together" can be asked
+    /// afterwards, of whichever hosts the asking suite owns.
+    private struct Span {
+        let id: Int
+        let host: String
+        let start: ContinuousClock.Instant
+        var end: ContinuousClock.Instant?
     }
 
     private struct State {
         var replies: [Route: Reply] = [:]
         var served: [URLRequest] = []
+        var spans: [Span] = []
+        /// Identity rather than position: `stopServing(host:)` can drop spans
+        /// while another suite's request is still open, and an index into the
+        /// array would then close somebody else's.
+        var nextSpanID = 0
         /// How many callers have asked for global registration. Counted rather
         /// than a flag: two suites can be installed at once, and the second one
         /// to finish is the one that may unregister.
@@ -67,6 +96,28 @@ final class StubTransport: URLProtocol {
     }
 
     private static let state = Mutex(State())
+
+    /// The one form a host is filed and asked for under. Hosts are
+    /// case-insensitive and `FeedSyncService` groups by the lowercased one, so
+    /// a stub that filed `Reddit.com` apart from `reddit.com` would report no
+    /// overlap for a pair production had already put in one group — a green
+    /// bought from a disagreement about spelling.
+    private static func key(_ host: String?) -> String { host?.lowercased() ?? "" }
+
+    /// How long the stub takes to answer.
+    ///
+    /// This is the width of the window an overlap can happen in: 50 ms is long
+    /// enough that two requests started together are both inside it, and two
+    /// orders of magnitude under `HostPacing.betweenRequests`' two seconds, so
+    /// a paced pair still never meets. A `DispatchTimeInterval` rather than the
+    /// `Duration` that value is, because `startLoading` is not async and GCD is
+    /// what it can schedule from: `Task`'s closure is `sending` and so cannot
+    /// carry `self`, which the reply has to be delivered through.
+    private static let serviceTime: DispatchTimeInterval = .milliseconds(50)
+
+    /// The span this instance opened, until it is closed. One request per
+    /// instance, so there is only ever one.
+    private let openSpan = Mutex<Int?>(nil)
 
     // MARK: Registering what to serve
 
@@ -83,9 +134,11 @@ final class StubTransport: URLProtocol {
     /// than wholesale: a suite tidying up after itself must not disarm one that
     /// is still running.
     static func stopServing(host: String) {
+        let host = key(host)
         state.withLock { state in
             state.replies = state.replies.filter { $0.key.host != host }
-            state.served = state.served.filter { $0.url?.host() != host }
+            state.served = state.served.filter { key($0.url?.host()) != host }
+            state.spans = state.spans.filter { $0.host != host }
         }
     }
 
@@ -95,11 +148,38 @@ final class StubTransport: URLProtocol {
     /// Scoped to a host because the record is shared: an unscoped "last
     /// request" would be another suite's the moment two run at once.
     static func requests(to host: String) -> [URLRequest] {
-        state.withLock { $0.served.filter { $0.url?.host() == host } }
+        let host = key(host)
+        return state.withLock { $0.served.filter { key($0.url?.host()) == host } }
     }
 
     static func lastRequest(to host: String) -> URLRequest? {
         requests(to: host).last
+    }
+
+    /// The most requests this stub ever had in flight at one moment, counting
+    /// only those to `hosts`.
+    ///
+    /// Scoped for the same reason `requests(to:)` is: the record is shared and
+    /// suites run in parallel, so an unscoped peak would count another suite's
+    /// traffic and read as concurrency this one never caused. Naming one host
+    /// is how "these never overlapped" is asked; naming a pair is how "these
+    /// did" is.
+    static func peakConcurrency(among hosts: String...) -> Int {
+        let wanted = Set(hosts.map(key))
+        let spans = state.withLock { $0.spans.filter { wanted.contains($0.host) } }
+        // A request still open counts up to now. Ends sort before starts at the
+        // same instant, so two requests that merely touch are not an overlap.
+        let now = ContinuousClock.now
+        let events = spans
+            .flatMap { [($0.start, 1), ($0.end ?? now, -1)] }
+            .sorted { ($0.0, $0.1) < ($1.0, $1.1) }
+        var inFlight = 0
+        var peak = 0
+        for (_, delta) in events {
+            inFlight += delta
+            peak = max(peak, inFlight)
+        }
+        return peak
     }
 
     // MARK: Installing
@@ -137,29 +217,57 @@ final class StubTransport: URLProtocol {
     // MARK: URLProtocol
 
     override class func canInit(with request: URLRequest) -> Bool {
-        guard let host = request.url?.host() else { return false }
+        guard let host = request.url?.host().map(key) else { return false }
         return state.withLock { $0.replies.keys.contains { $0.host == host } }
     }
 
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
 
     override func startLoading() {
-        let reply = Self.state.withLock { state -> Reply? in
+        let url = request.url
+        let host = Self.key(url?.host())
+        let (reply, spanID) = Self.state.withLock { state -> (Reply?, Int) in
             state.served.append(request)
-            return Route(request.url).flatMap { state.replies[$0] }
+            state.nextSpanID += 1
+            state.spans.append(Span(id: state.nextSpanID, host: host, start: .now, end: nil))
+            return (Route(url).flatMap { state.replies[$0] }, state.nextSpanID)
         }
-        // A path nobody registered fails rather than serving an empty 200: a
-        // setup mistake should not read as a Source with no news.
-        guard let reply else {
-            client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
-            return
+        openSpan.withLock { $0 = spanID }
+
+        // Answering off this thread rather than from here is what leaves a
+        // request in flight long enough for a second to be in flight alongside.
+        DispatchQueue.global().asyncAfter(deadline: .now() + Self.serviceTime) { [self] in
+            guard closeSpan() else { return }   // cancelled before we answered
+            // A path nobody registered fails rather than serving an empty 200:
+            // a setup mistake should not read as a Source with no news.
+            guard let reply, let url else {
+                client?.urlProtocol(self, didFailWithError: URLError(.fileDoesNotExist))
+                return
+            }
+            let response = HTTPURLResponse(url: url, statusCode: reply.status,
+                                           httpVersion: nil, headerFields: nil)!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: reply.body)
+            client?.urlProtocolDidFinishLoading(self)
         }
-        let response = HTTPURLResponse(url: request.url!, statusCode: reply.status,
-                                       httpVersion: nil, headerFields: nil)!
-        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-        client?.urlProtocol(self, didLoad: reply.body)
-        client?.urlProtocolDidFinishLoading(self)
     }
 
-    override func stopLoading() {}
+    override func stopLoading() { _ = closeSpan() }
+
+    /// Marks this instance's request no longer in flight. Returns whether it
+    /// was this call that closed it, so a cancellation and a late answer cannot
+    /// both act.
+    private func closeSpan() -> Bool {
+        let id = openSpan.withLock { open -> Int? in
+            defer { open = nil }
+            return open
+        }
+        guard let id else { return false }
+        Self.state.withLock { state in
+            if let index = state.spans.firstIndex(where: { $0.id == id }) {
+                state.spans[index].end = .now
+            }
+        }
+        return true
+    }
 }

--- a/Tests/UnitTests/StubTransportTests.swift
+++ b/Tests/UnitTests/StubTransportTests.swift
@@ -108,6 +108,60 @@ struct StubTransportTests {
         #expect(String(decoding: data, as: UTF8.self) == "still served")
     }
 
+    @Test("two requests issued at once read as in flight together")
+    func concurrentRequestsOverlap() async throws {
+        StubTransport.stopServing(host: host)
+        defer { StubTransport.stopServing(host: host) }
+        StubTransport.serve(url("/one"), body: "first")
+        StubTransport.serve(url("/two"), body: "second")
+
+        let session = StubTransport.session()
+        async let first = session.data(from: url("/one"))
+        async let second = session.data(from: url("/two"))
+        _ = try await (first, second)
+
+        // The property #44's pacing is asserted against. A stub that answered
+        // inside `startLoading` would report 1 here and would then report 1 for
+        // a sync that paced nothing.
+        #expect(StubTransport.peakConcurrency(among: host) == 2)
+    }
+
+    @Test("requests made one after another never read as in flight together")
+    func sequentialRequestsDoNotOverlap() async throws {
+        StubTransport.stopServing(host: host)
+        defer { StubTransport.stopServing(host: host) }
+        StubTransport.serve(url("/one"), body: "first")
+        StubTransport.serve(url("/two"), body: "second")
+
+        let session = StubTransport.session()
+        _ = try await session.data(from: url("/one"))
+        _ = try await session.data(from: url("/two"))
+
+        #expect(StubTransport.peakConcurrency(among: host) == 1)
+    }
+
+    @Test("a host nobody named is not counted as concurrency")
+    func concurrencyIsScopedToTheHostsNamed() async throws {
+        let other = "other.test"
+        defer {
+            StubTransport.stopServing(host: host)
+            StubTransport.stopServing(host: other)
+        }
+        StubTransport.stopServing(host: host)
+        StubTransport.stopServing(host: other)
+        StubTransport.serve(url("/one"), body: "first")
+        StubTransport.serve(URL(string: "https://\(other)/one")!, body: "other")
+
+        let session = StubTransport.session()
+        async let first = session.data(from: url("/one"))
+        async let second = session.data(from: URL(string: "https://\(other)/one")!)
+        _ = try await (first, second)
+
+        // Suites run in parallel, so an unscoped peak would be another suite's.
+        #expect(StubTransport.peakConcurrency(among: host) == 1)
+        #expect(StubTransport.peakConcurrency(among: host, other) == 2)
+    }
+
     @Test("clearing one host leaves another serving")
     func clearingIsPerHost() async throws {
         defer {
@@ -124,5 +178,7 @@ struct StubTransportTests {
                                        session: StubTransport.session())
         #expect(String(decoding: data, as: UTF8.self) == "other")
         #expect(StubTransport.requests(to: host).isEmpty)
+        #expect(StubTransport.peakConcurrency(among: host) == 0,
+                "what it served is forgotten along with when it served it")
     }
 }

--- a/docs/adr/0002-three-kinds-of-concept-edge.md
+++ b/docs/adr/0002-three-kinds-of-concept-edge.md
@@ -52,8 +52,17 @@ Semantic Links to each other and visibly clutter the map.
 
 **Amended (2026-08-20):** the cliff is gone — `ConceptIndex` holds each name's
 meaning instead of recomputing it, which is what made the scan unaffordable and
-bought the ceiling (#11). The stakes this consequence names are not yet
-answered, though: measured against the shipped threshold, the embedding merges
-neither a plural nor an abbreviation, so near-duplicates still accumulate at
-every map size rather than only above 500. Calibrating that threshold against
-real Concept names is the open half.
+bought the ceiling (#11). The stakes this consequence names were not answered by
+that, though: measured against the threshold as it then stood, 0.25, the
+embedding merged neither a plural nor an abbreviation, so near-duplicates
+accumulated at every map size rather than only above 500. Calibrating that
+threshold against real Concept names was the open half.
+
+**Amended (2026-08-21):** that half is answered by
+[ADR-0010](0010-de-duplication-is-calibrated-and-folds-spelling-first.md) — the
+threshold is calibrated at 0.50 against every pair of names the built-in Packs
+contain, and spelling is folded before meaning is asked, so plurals, separators
+and "&" for "and" merge. The paragraph above said the embedding "merges neither
+a plural nor an abbreviation"; a plural it now merges, and an abbreviation it
+still cannot, at any threshold — `LLM` and `Large Language Models` are 1.26
+apart, so they remain two dots on the map (#41).

--- a/docs/adr/0003-hot-topics-are-observed-not-curated.md
+++ b/docs/adr/0003-hot-topics-are-observed-not-curated.md
@@ -50,7 +50,15 @@ Sources inside one group go one at a time with `HostPacing.betweenRequests`
 between requests. The visible-health half is still open (**#14**) — a Source
 that comes back with nothing still says so to nobody.
 
-Intake is capped at 30/day sorted newest-first, so a "top this week" entry
-carrying a six-day-old timestamp loses to same-day arXiv papers by construction.
-Whatever surfaces Hot Topics cannot rely on those articles winning the newest
--first race.
+Intake is capped at 30/day. It *was* also sorted newest-first across every
+Source pooled together, so a "top this week" entry carrying a timestamp up to
+six days old lost to same-day arXiv papers by construction — this consequence
+originally ended "whatever surfaces Hot Topics cannot rely on those articles
+winning the newest-first race", and under that allocator it was right.
+[ADR-0009](0009-daily-intake-is-shared-between-sources-not-won-by-recency.md)
+removed the global sort: the cap is spent round-robin, one item per Source per
+turn, and a Source's own ordering decides which of its items go. So an older
+entry now takes its turn like any other, and the flagship gained the
+vote-ranked Source this consequence said could not work (#45, #46). The cap
+itself is unchanged, and is still a habit decision rather than a technical
+one.

--- a/docs/adr/0003-hot-topics-are-observed-not-curated.md
+++ b/docs/adr/0003-hot-topics-are-observed-not-curated.md
@@ -33,12 +33,22 @@ vote-sorted, while remaining just another Source.
 
 ## Consequences
 
-Reddit throttles aggressively: a back-to-back fetch of a second subreddit
-returned **HTTP 429** during this investigation, with the existing custom
-User-Agent set. `FeedSyncService` fetches every Source concurrently in a task
-group and swallows failures with `try?`, so several subreddits will silently
-yield nothing. Per-host request pacing and visible Source health (ROADMAP item
-12) become prerequisites rather than nice-to-haves.
+Reddit throttles aggressively, and not only against bursts: a back-to-back
+fetch of a second subreddit returned **HTTP 429** during this investigation,
+with the existing custom User-Agent set — and #43 later watched
+`r/MachineLearning/top/.rss?t=week` return **429 and then zero bytes** on plain
+*sequential* fetches two minutes apart. So pacing makes the app a well-behaved
+client; what it cannot do is buy an answer from this host, and no client-side
+number can.
+
+`FeedSyncService` fetched every Source concurrently in one task group and
+swallowed failures with `try?`, so several subreddits silently yielded nothing.
+Per-host request pacing and visible Source health (ROADMAP item 12) were
+therefore prerequisites rather than nice-to-haves. The pacing half shipped in
+**#44**: Sources are grouped by URL host, the groups run concurrently, and the
+Sources inside one group go one at a time with `HostPacing.betweenRequests`
+between requests. The visible-health half is still open (**#14**) — a Source
+that comes back with nothing still says so to nobody.
 
 Intake is capped at 30/day sorted newest-first, so a "top this week" entry
 carrying a six-day-old timestamp loses to same-day arXiv papers by construction.

--- a/docs/adr/0007-explain-matches-the-map-on-spelling-not-on-meaning.md
+++ b/docs/adr/0007-explain-matches-the-map-on-spelling-not-on-meaning.md
@@ -42,9 +42,14 @@ tested rather than restated in a `first(where:)`.
   do. And the similarity threshold that is safe for *deduping a result the model
   already returned* is not the same threshold as *deciding not to ask*: a false
   positive there shows the reader a definition of a Concept they did not tap,
-  offline, with nothing to signal that a substitution happened. The current
-  0.25 distance was chosen for the first job. Buying synonym coverage with a
-  silent wrong answer is a bad trade in a reading app.
+  offline, with nothing to signal that a substitution happened. The distance was
+  chosen for the first job. Buying synonym coverage with a silent wrong answer
+  is a bad trade in a reading app.
+
+  **Correction (2026-08-21):** this bullet read "The current 0.25 distance was
+  chosen for the first job". The distance is 0.50 since ADR-0010 calibrated it,
+  and the reasoning is unchanged — a threshold safe for deduping a result the
+  model already returned is still not the one for deciding not to ask (#41).
 - **Leave the code, narrow the ADR.** Honest, and cheap: ADR-0006's sentence
   would become "words already on the map under the name the Pack gave them",
   which is true of the code as it stood. Rejected because the shape it concedes
@@ -80,3 +85,12 @@ the dedupe path: the two never run on the same term (Explain returns before
 generating when the map already has the word), and the embedding match there is
 doing a job it is correctly threshold-tuned for. Widening dedupe is a separate
 decision about Pack installation, not about what leaves the device.
+
+**Amended (2026-08-21):** that decision has since been taken —
+[ADR-0010](0010-de-duplication-is-calibrated-and-folds-spelling-first.md)
+applies this fold to `ConceptIndex.match` as well, and moves the threshold to
+0.50. The clause about being "correctly threshold-tuned" is the part that did
+not survive a measurement: at 0.25 the embedding match merged nothing a name
+match did not already merge (#41). Explain routes the same selections the same
+way it did before, and the most that leaves the device is what this ADR left —
+a selected word the map has no name and no fold for, on the opt-in path.

--- a/docs/adr/0009-daily-intake-is-shared-between-sources-not-won-by-recency.md
+++ b/docs/adr/0009-daily-intake-is-shared-between-sources-not-won-by-recency.md
@@ -21,8 +21,19 @@ reader subscribed to. It does not merely disadvantage a popularity-ranked
 Source; it deletes the only property that made it worth adding.
 
 **Decision:** intake is allocated **round-robin across Sources** — each Source
-offers its own newest-first, and the cap is spent one item per Source per turn
-until exhausted. Global recency ordering is removed as the allocator.
+offers its own items in its own order, and the cap is spent one item per Source
+per turn until exhausted. Global recency ordering is removed as the allocator.
+Round-robin governs **how many** items a Source contributes and never **which**.
+
+**Correction (2026-08-21):** this sentence read "each Source offers its own
+newest-first". Implementing it (#45) showed that sorting a Source's own items
+by date reproduces this ADR's own fault one level down. A "top this week"
+entry is up to six days old, so newest-first *inside* the Source hands over
+that Source's newest items rather than its best ones — deleting the popularity
+ordering exactly as the global sort deleted it, only more quietly. The
+paragraph above already carried the rule that settles it: *what a Source is
+ordered by is part of what you subscribed to*. Most feeds are newest-first and
+so offer their newest first, which is why the wrong sentence read as harmless.
 
 ## Considered options
 

--- a/docs/adr/0010-de-duplication-is-calibrated-and-folds-spelling-first.md
+++ b/docs/adr/0010-de-duplication-is-calibrated-and-folds-spelling-first.md
@@ -1,0 +1,108 @@
+# De-duplication is calibrated, and folds spelling before it asks about meaning
+
+ADR-0002 gave the map three kinds of edge and left a consequence open: near-
+duplicate Concepts gain strong Semantic Links to each other and clutter the map,
+and de-duplication was not catching them. #11 removed the 500-Concept ceiling
+that switched merging off on exactly the maps that needed it. What was left was
+the threshold, `ConceptIndex.sameIdeaDistance`, at 0.25.
+
+Measured, 0.25 admits nothing. Not a plural (`world model` ~ `world models` is
+0.449), and not "LLM" ≈ "Large Language Models" (1.26), which the doc comment on
+`findOrCreateConcept` advertised from the day it was written. Matching by
+meaning was doing nothing matching by name did not already do, at every map size
+(#41).
+
+Widening it by eye is worse than leaving it narrow. A merge is destructive: the
+incoming Concept is never created, so Mastery, Lit state and `LearningEvent`
+history consolidate onto whichever name arrived first. #11's own first draft
+used a metric eight times too permissive and merged "supervised learning" into
+"unsupervised learning".
+
+**Decision:** the threshold is **0.50**, derived the way `SemanticLinker`'s
+relatedness floor was — from measurements over real Concept names, written down
+beside the constant — and `ConceptIndex.match` **folds spelling before it asks
+about meaning**, using `ConceptMatch.fold`, the fold Explain already uses.
+
+The measurement is every pair of the 120 Concept names the two built-in Packs
+contain — 7,140 of them — against restatements of those same names written the
+way an Article's analysis says them. The two halves split the work, and only
+what is left to the distance decides where the distance goes:
+
+| what is left for the distance to merge | measured |
+| --- | --- |
+| "&" spelled "and": `Identity & Access Management` | 0.24–0.30 |
+| one letter of spelling: `Defence`, `Modelling`, `Quantisation` | 0.33–0.38 |
+| an article in front: `The Transformer Architecture` | 0.392 |
+| **nothing the fold does not already have** | **0.39–0.62** |
+| the closest two distinct names ship (`Vision Language Models` ~ `Reasoning Models`) | 0.620 |
+| `Batch Normalization` ~ `Layer Normalization` | 0.635 |
+| `Supervised Learning` ~ `Unsupervised Learning` | 0.691 |
+
+0.50 is the middle of that empty stretch — 0.11 above the widest restatement the
+distance carries, 0.12 below the closest pair of distinct names either Pack
+contains. The margins are not equally valuable, which is why the empty stretch
+being wide enough to hold both matters: being wrong on the low side costs a
+reader a duplicate dot, and on the high side their history.
+
+The fold takes the rest, and it is a band no threshold could have had: plurals
+and separators from 0.33 to 0.57, including a plural of a *one-word* name
+(`Benchmarks` ~ `Benchmark`, 0.67; `Guardrails` ~ `Guardrail`, 0.75) which sits
+among the distinct pairs, because one word of a one-word name is the whole of
+its meaning.
+
+## Considered options
+
+- **Widen the threshold far enough to catch one-word plurals.** It would have
+  to reach past 0.75, and two distinct names the flagship ships are 0.62 apart.
+  Rejected: that is not a wider threshold, it is merging the Pack into itself.
+- **Fold spelling and leave the threshold at 0.25.** Catches the plurals and
+  the hyphens, and nothing else — an "&" spelled "and", `Defence` for `Defense`,
+  and a Concept restated in different words all still make a second dot.
+  Rejected: the measurement says the safe band is real and 0.25 is not near it.
+- **0.55, the middle of the stretch with nothing measured in it *at all*.**
+  Rejected once the two halves were separated: every restatement between 0.39
+  and 0.57 is one the fold already merges, so the extra 0.05 buys nothing that
+  was measured and spends margin on the destructive side.
+- **Keep the fold out of the dedupe path, as ADR-0007 left it.** That ADR
+  declined to apply the fold here on the grounds that widening dedupe was a
+  separate decision about Pack installation. It is; this is that decision, taken
+  with the measurements ADR-0007 did not have.
+- **A stemmer, or a synonym list, for abbreviations.** Rejected as out of reach
+  of this instrument rather than out of scope for this map: `rag` ~ `retrieval
+  augmented generation` is 1.32, further apart than two unrelated Concepts, so
+  no threshold on a sentence embedding can have it. Catching abbreviations needs
+  something that is not a sentence embedding, and is its own decision.
+
+## Consequences
+
+**The limits are stated, not implied.** An abbreviation still makes a second dot
+on the map — `LLM` beside `Large Language Models` — and so does one letter
+inside a one-word name (`Tokenisation`, 0.578, which folds differently too).
+Both are written beside the constant and asserted in `ConceptDedupeTests`, so
+the next person to read the threshold reads what it does not do.
+
+**A Pack whose own names merge into each other is now a test failure.**
+`builtinPacksHoldNoPairInsideTheThreshold` measures every pair of names both
+built-in Packs contain, on both halves of the match. It is the calibration
+itself, kept runnable: a Pack that adds a name 0.45 from one already there, or
+one that folds onto it, fails the suite rather than losing a reader's history in
+the field.
+
+**Hot Topics suppresses more, and the terms it lets through are measured too.**
+`HotTopics.candidates` asks the same question with the same constant, and now
+the same fold. Before the fold, "Benchmarks" could be offered to a map holding
+"Benchmark" and adopting it would merge straight back into the Concept the
+reader had. What the widening might have cost is the growth the feature exists
+to catch, so that side is a test as well:
+`realEmbeddingStillOffersWhatIsGenuinelyNew` runs rising terms against the whole
+flagship Pack with the model that ships, "small models" among them — the nearest
+any measured term came to a Concept name, at 0.570, and still offered.
+
+**ADR-0002's open half is closed.** Its consequence about the de-duplication
+cliff is amended to point here.
+
+**ADR-0007's boundary moved, and only for dedupe.** Explain still matches the
+map on spelling and not on meaning: what changed is what `findOrCreateConcept`
+merges *after* a generation, not what a selection sends. The most that leaves
+the device is what ADR-0006 enumerated and what ADR-0007 narrowed — a selected
+word the map has no name and no fold for, on the opt-in path.


### PR DESCRIPTION
Closes #41.

`ConceptIndex.sameIdeaDistance` was 0.25, and measured against the embedding
that ships it admitted nothing: not a plural (`world model` ~ `world models`,
0.449), and not "LLM" ≈ "Large Language Models" (1.26), the pair
`findOrCreateConcept`'s doc comment advertised from the day it was written.
Matching by meaning was doing nothing matching by name did not already do, at
every map size.

## The calibration

Every pair of the 120 Concept names the two built-in Packs contain — 7,140 of
them — measured against restatements of those names written the way an
Article's analysis says them. Splitting the restatements by which half of the
match has to catch them is what set the number:

| what is left for the distance to merge | measured |
| --- | --- |
| "&" spelled "and": `Identity & Access Management` | 0.24–0.30 |
| one letter of spelling: `Defence`, `Modelling`, `Quantisation` | 0.33–0.38 |
| an article in front: `The Transformer Architecture` | 0.392 |
| **nothing the fold does not already have** | **0.39–0.62** |
| closest two distinct names ship: `Vision Language Models` ~ `Reasoning Models` | 0.620 |
| `Batch Normalization` ~ `Layer Normalization` | 0.635 |
| `Supervised Learning` ~ `Unsupervised Learning` | 0.691 |

**0.50** is the middle of that empty stretch — 0.11 above the widest
restatement the distance carries, 0.12 below the closest pair of distinct names
either Pack contains. The margins are not equally valuable: a merge is
destructive, because the incoming Concept is never created and Mastery, Lit
state and `LearningEvent` history consolidate onto whichever name arrived
first, where a near-duplicate only clutters.

The table lives beside the constant, not in this description.

## The fold

`ConceptIndex.match` folds spelling before it asks about meaning, reusing
`ConceptMatch.fold` — the fold Explain has used since ADR-0007. A plural of a
*one-word* name (`Benchmarks` ~ `Benchmark`, 0.67; `Guardrails` ~ `Guardrail`,
0.75) sits among the distinct pairs, because one word of a one-word name is the
whole of its meaning, so no threshold could ever have had it. The fold has it,
and the plurals and separators between 0.33 and 0.57 with it.

`HotTopics.candidates` folds too. It asks the same question with the same
constant, and without the fold it could offer "Benchmarks" to a map holding
"Benchmark" — a chip that adds nothing when tapped, because `adopt` goes
through `findOrCreateConcept` and merges straight back.

## What remains out of reach, stated where the constant is

- **Abbreviations**: `rag` ~ `retrieval augmented generation` is 1.32 — further
  apart than two unrelated ideas, so no threshold on a sentence embedding can
  have them. Needs a different instrument, and is its own decision.
- **One letter inside a one-word name**: `Quantisation` merges at 0.377, but
  `Tokenisation` is 0.578 and folds differently.

## Tests

409 unit tests (four new, one rewritten) and the four UI journeys pass. The
tests over the real embedding are the calibration kept runnable rather than
written down twice:

- `builtinPacksHoldNoPairInsideTheThreshold` — every pair of names both built-in
  Packs contain, on both halves of the match. A Pack that adds a name 0.45 from
  one already there fails the suite instead of losing a reader's history in the
  field.
- `realEmbeddingMergesRestatements` — seventeen restatements through
  `findOrCreateConcept` with the model that ships.
- `theCalibrationTheThresholdCameFrom` — the band and the limits.
- `realEmbeddingStillOffersWhatIsGenuinelyNew` — the direction the widening
  could have cost something: rising terms against the whole flagship Pack, still
  offered.

No test asserts the threshold's behaviour on injected vectors. The ones that
inject are about what the index does — no ceiling, a Concept created part way
through a pass matchable by the end of it, which thread waits — and three of
their fixtures were renamed off "World Model" ~ "World Models" and "LLM" ~
"Large Language Models", so that neither the fold nor a documented
impossibility stands in for the path they exist to test.

## What the review changed

The first draft was **0.55**, the middle of the stretch with nothing measured in
it at all. The spec axis pointed out that every restatement between 0.39 and
0.57 is one the fold already merges, so the extra 0.05 bought nothing measured
and spent it on the destructive side. The standards axis caught a stale sentence
in ADR-0002 left standing under a correction note, an ADR-0007 line edited
without quoting what it used to say, and several absolutes in new prose.

## Docs

- **ADR-0010** records the decision.
- **ADR-0002**'s consequence about the de-duplication cliff: its open half is
  closed, and the stale sentence is fixed as well as annotated.
- **ADR-0007**'s "`findOrCreateConcept` is deliberately untouched" consequence is
  amended to point here. Explain is unchanged — what moved is what
  `findOrCreateConcept` merges after a generation, not what a selection sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6k9KkbUUZKopxq69UJaCA