### PR TITLE
The 🔥 lane stops embedding the map on the main actor (#49)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -45,6 +45,76 @@ sequential case, which was never the one at risk. Making a function `async` does
 not change what its tests assert; it changes which orderings can reach it, and a
 test written before the suspension existed cannot know about the ones it added.
 Found by the spec axis of the review on #50, not by the suite.
+## 2026-08-21 — The 🔥 lane stops embedding the map on the main actor (#49)
+
+**Built**
+- **`HotTopics.candidates` is `async`, and gets the map's meanings from
+  `SemanticLinker.meanings`.** It judged whether a rising term was already on
+  the map by meaning, and embedded every Concept name to do it — synchronously,
+  on the main actor, from two places in `FeedView` that both hold it. That is
+  #42's two seconds again, on the same screen, in the same `task`.
+- **Why #42 did not already cover it.** The memo in `SemanticLinker.embed` is
+  shared and keyed the same way both paths key it, so when analysis runs first
+  the lane finds every vector already computed and costs nothing. But
+  `analyzePending` early-returns when no Article is waiting for a summary —
+  which is every launch where the reader is caught up — and `.onChange` never
+  had analysis in front of it at all. The cost landed on the first rising term
+  the map cannot name, which is the case the lane exists to catch.
+- **One batch primitive, two callers.** `ConceptIndex.prepared`'s private
+  `meanings` moved onto `SemanticLinker` as `meanings(of:using:)`, where it sits
+  beside the `embed` it calls. `nonisolated async`, so calling it from the main
+  actor leaves it, and it hands back a whole table — which is what lets both
+  callers' rules stay synchronous: `ConceptIndex.match` has nowhere to await,
+  and `candidates` weighs a lane against a map in one pass.
+- **Spelling first, and it can end the whole thing.** The fold and the
+  containment check run before the suspension, over names already in memory. A
+  reader with nothing rising the map cannot name embeds nothing at all; what
+  survives is embedded in the same batch as the map, so a lane costs one
+  suspension however long it is.
+- **The Feed awaits it in a cancellable `Task`.** `rising` stays synchronous, so
+  the 🔥 filter has its vocabulary the moment the feed changes; the strip fills
+  when the pass returns. It deliberately does not show the spelling pass's
+  answer first and narrow it: suppression is the point of the offer, not a
+  refinement of it, and the chips withdrawn would be exactly the duplicates
+  `candidates` exists to keep off the screen. The offer already on screen stays
+  standing meanwhile rather than being cleared — collapsing the strip on every
+  sync would move the article list under the reader's thumb to say nothing.
+- **Late assignment needed two cancellations, not one.** A new observation
+  cancels the one in flight, so a sync landing mid-pass cannot be overwritten by
+  an older one. Accepting a chip cancels it too: `adopt` drops the term from
+  `candidates` by hand rather than recomputing — the comment there has always
+  said `allConcepts` does not refresh in time — and a pass started before the
+  adoption would land afterwards and put the chip back. Assigning synchronously
+  used to make that ordering safe for free.
+
+**Nothing caps the map size.** No count-based cut-off went in, here or anywhere
+near it. Making the lane smaller to dodge the cost is the shape of #11's
+500-Concept ceiling — switching the check off at the size where a reader has
+most to gain from it.
+
+**Verified** 411 unit tests; the full suite passes, and the four UI journeys
+with it.
+`HotCandidateTests.candidatesDoNotBlockTheMainActor` is the new one, at the seam
+both Feed callers reach the check through: 600 Concepts with names unique to the
+test so the launch-long memo is cold whichever order the suite runs in, the real
+embedding, and main-actor time measured rather than wall clock. 57 ms held, of a
+2.2 s pass, against 1.46 s held before; it carries an absolute bar as well as the
+ratio, which is what bounds the arithmetic left on the main actor after the
+embedding hops off — a distance per Concept per term, at 600 Concepts. Every other
+assertion in `HotCandidateTests` is unchanged — the lane offers what it offered
+and suppresses what it suppressed — and the eleven tests that called
+`candidates` synchronously now await it.
+
+**Learned: the heartbeat was not measuring the failure it was named for.**
+`mainActorStall` — #42's harness, now shared out of `ConceptDedupeTests` into
+`Tests/UnitTests/MainActorStall.swift` — started its heartbeat task and went
+straight into the work. Work that never yields runs to completion before the
+heartbeat's first beat, so it set its clock *after* the freeze and reported no
+stall at all: the new test passed against the unfixed code, at 1.4 s of frozen
+main actor. One `await Task.yield()` between starting the heartbeat and starting
+the clock fixes it, and the same test then failed honestly. Both of #42's
+measurements still pass under the stricter harness, which is the evidence that
+what it claimed was true and only its proof was thin.
 
 ## 2026-08-21 — The de-duplication threshold is measured rather than guessed (#41)
 

--- a/TechPulse.xcodeproj/project.pbxproj
+++ b/TechPulse.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		453B0A7702E4A1224840AC2A /* RSSParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3888CD6831CCA2655369901B /* RSSParserTests.swift */; };
 		46FE11B0203CB7421E08B2DD /* HabitEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCF7B94959D93C993B9F598 /* HabitEngine.swift */; };
 		4823EDDF5E54AFD727A94E38 /* ExplainRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B6A636A34EAB579EEDCC0 /* ExplainRouteTests.swift */; };
+		4903CE75CCD4D0017ED9BE27 /* MainActorStall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF4B81619B7930D334EA1C /* MainActorStall.swift */; };
 		4A2B4EC62E3B4BF6E10CD9CC /* SelectableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8740BCA165AACC9103823F /* SelectableText.swift */; };
 		4BAB76528DBE7F0990A79C24 /* HotCandidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5879146652A224AF36498CDE /* HotCandidateTests.swift */; };
 		4BF6AF14EDF50A14C3F4205E /* TopicSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C4D1DACE42EDDAAD7384F6 /* TopicSearchService.swift */; };
@@ -183,6 +184,7 @@
 		2A8587075ACC8C5B50E579FD /* ForceGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForceGraphView.swift; sourceTree = "<group>"; };
 		2B07EE9C61977870716F7F9E /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		2E37A1B81DE21F03EB89D165 /* PackFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackFileTests.swift; sourceTree = "<group>"; };
+		30BF4B81619B7930D334EA1C /* MainActorStall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainActorStall.swift; sourceTree = "<group>"; };
 		3217DDB8C0FCEF782C439924 /* KnowledgeEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeEngineTests.swift; sourceTree = "<group>"; };
 		32AFBF580D137E09E6248B83 /* TechPulseWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TechPulseWidget.entitlements; sourceTree = "<group>"; };
 		3622BA0341099C2B7B34C775 /* TechPulseWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TechPulseWidgetBundle.swift; sourceTree = "<group>"; };
@@ -373,6 +375,7 @@
 				7EA816A669366B690E5244D9 /* JourneyLedgerTests.swift */,
 				3217DDB8C0FCEF782C439924 /* KnowledgeEngineTests.swift */,
 				65E7E29ED174FA263DEDB606 /* KnowledgePathTests.swift */,
+				30BF4B81619B7930D334EA1C /* MainActorStall.swift */,
 				FC06445AEC3AEA0A988E1A48 /* PackDrivenPathTests.swift */,
 				2E37A1B81DE21F03EB89D165 /* PackFileTests.swift */,
 				EC0E3D4D133232BE13D2D895 /* PackInstallerTests.swift */,
@@ -652,6 +655,7 @@
 				C9772C9336CD0D3D3A7EEBC3 /* JourneyLedgerTests.swift in Sources */,
 				6E32EDEC254288E369341A50 /* KnowledgeEngineTests.swift in Sources */,
 				13C837292A832847D26998B4 /* KnowledgePathTests.swift in Sources */,
+				4903CE75CCD4D0017ED9BE27 /* MainActorStall.swift in Sources */,
 				117C1701890EA77A9FFF1E2B /* PackDrivenPathTests.swift in Sources */,
 				AD3AF80B7D4B0DC6B5720FA4 /* PackFileTests.swift in Sources */,
 				B93232B2770B97869ACA2F64 /* PackInstallerTests.swift in Sources */,

--- a/TechPulse/Services/ConceptIndex.swift
+++ b/TechPulse/Services/ConceptIndex.swift
@@ -138,34 +138,9 @@ struct ConceptIndex {
                          vector: @escaping @Sendable (String) -> [Double]? = SemanticLinker.embed)
     async -> ConceptIndex {
         var index = ConceptIndex(concepts, vector: vector)
-        index.vectors = await meanings(of: Array(index.concepts.keys), from: vector)
+        index.vectors = await SemanticLinker.meanings(of: Array(index.concepts.keys),
+                                                      using: vector)
         return index
-    }
-
-    /// Embeds a batch of names away from whoever asked.
-    ///
-    /// `nonisolated` and `async`, so calling it from the main actor leaves it:
-    /// under Swift 6.0 a nonisolated async function runs on the generic
-    /// executor, and the caller suspends rather than spinning. Handing back a
-    /// whole table rather than making callers await a name at a time is what
-    /// keeps `match` synchronous.
-    ///
-    /// That is a language rule, not a promise this code makes, and adopting
-    /// `nonisolated(nonsending)` as the default would hand this loop back to
-    /// the caller's actor and #42 with it. The test that would notice is
-    /// `preparingAnIndexDoesNotBlockTheMainActor`, which is why it measures
-    /// main-actor time rather than how long the build took.
-    private nonisolated static func meanings(
-        of names: [String],
-        from vector: @escaping @Sendable (String) -> [Double]?
-    ) async -> [String: [Double]] {
-        var meanings: [String: [Double]] = [:]
-        meanings.reserveCapacity(names.count)
-        // A name the embedding cannot place is remembered as empty rather than
-        // left out, so it is not attempted again for the life of the index —
-        // the same bargain `meaning(of:)` strikes.
-        for name in names { meanings[name] = vector(name) ?? [] }
-        return meanings
     }
 
     /// The Concept already standing for this name: spelled it, spelled it

--- a/TechPulse/Services/HotTopics.swift
+++ b/TechPulse/Services/HotTopics.swift
@@ -196,24 +196,46 @@ enum HotTopics {
     /// against vectors a test chooses rather than whatever Apple's model
     /// believes about AI jargon.
     ///
+    /// ## Why it is `async`
+    ///
+    /// Embedding each name once made the count small; it left the work where it
+    /// was. A 600-Concept map is still two seconds of embedding, and both of
+    /// the Feed's callers hold the main actor while this runs — `FeedView.task`,
+    /// which reaches here directly on a launch with nothing pending to analyse,
+    /// and `.onChange`, a view callback with nowhere to await at all. So the
+    /// map's meanings come from `SemanticLinker.meanings`, which leaves the main
+    /// actor to compute them, and the rules below read a table (#49). What stays
+    /// here is the fold, and one distance per Concept per surviving term —
+    /// arithmetic over vectors already in hand, bounded by
+    /// `HotCandidateTests.candidatesDoNotBlockTheMainActor` at 600 Concepts.
+    ///
+    /// Nothing is embedded for a term the map already has by name, and nothing
+    /// at all for a reader with nothing rising — the spelling pass runs first
+    /// and can end the whole thing. What survives it is embedded in the same
+    /// batch as the map, so there is one suspension however long the lane is.
+    ///
+    /// The map's size is not consulted anywhere here. Switching the meaning
+    /// check off above some count is #11's ceiling, which refused to merge at
+    /// exactly the map size a reader has most to gain from it.
+    ///
     /// Offers only. Nothing here writes to the store: ADR-0001 keeps the map
     /// the reader's, and a Concept that appeared because an article mentioned
     /// something twice is not theirs.
     static func candidates(from terms: [HotTerm], concepts: [Concept],
-                           vector: @Sendable (String) -> [Double]? = SemanticLinker.embed)
-    -> [HotTerm] {
+                           vector: @escaping @Sendable (String) -> [Double]?
+                               = SemanticLinker.embed)
+    async -> [HotTerm] {
         let names = concepts.map { $0.name.lowercased() }
         // Folded once per name rather than once per pair. String work, unlike
         // the vectors below, so it is not worth making lazy.
         // Without the empty key, which is what an unnameable Concept folds to
         // and is not something a term should match.
         let foldedNames = Set(names.map(ConceptMatch.fold)).subtracting([""])
-        // Embedded lazily: a term that matches by name never asks for meaning,
-        // and a reader with nothing rising never embeds anything at all.
-        var mapVectors: [[Double]]?
 
-        var offered: [HotTerm] = []
-        for term in terms where offered.count < candidateLimit {
+        // Carried as a pair, because the lowercased text is what the rules
+        // below key on and folding it three times to save a word would be the
+        // string work this pass exists to do once.
+        let unnamed = terms.compactMap { term -> (term: HotTerm, text: String)? in
             let text = term.text.lowercased()
             // One direction only. A Concept named "World Model Research" already
             // covers "world model", so that term is a duplicate — but a map
@@ -223,15 +245,28 @@ enum HotTopics {
             // lane wants it to be; membership does not.
             let named = foldedNames.contains(ConceptMatch.fold(text))
                 || names.contains { name in name == text || covers(name, text) }
-            if named { continue }
+            return named ? nil : (term, text)
+        }
+        guard !unnamed.isEmpty else { return [] }
 
-            if mapVectors == nil { mapVectors = names.map { vector($0) ?? [] } }
-            let termVector = vector(text) ?? []
-            let meant = zip(names, mapVectors ?? []).contains { _, mapVector in
-                SemanticLinker.distance(between: termVector, and: mapVector)
+        // The map and the terms left to weigh against it, in one batch and one
+        // suspension. Terms past `candidateLimit` are embedded too: whether an
+        // earlier one takes the slot is what the meaning check is about to
+        // decide, and that is at most a lane's worth of names against a map's.
+        let meanings = await SemanticLinker.meanings(of: names + unnamed.map(\.text),
+                                                     using: vector)
+
+        var offered: [HotTerm] = []
+        for candidate in unnamed where offered.count < candidateLimit {
+            // An empty vector is a name the embedding could not place, and
+            // `distance` refuses it — so an unplaceable term is offered rather
+            // than silently matched against everything.
+            let termVector = meanings[candidate.text] ?? []
+            let meant = names.contains { name in
+                SemanticLinker.distance(between: termVector, and: meanings[name] ?? [])
                     .map { $0 < ConceptIndex.sameIdeaDistance } ?? false
             }
-            if !meant { offered.append(term) }
+            if !meant { offered.append(candidate.term) }
         }
         return offered
     }

--- a/TechPulse/Services/SemanticLinker.swift
+++ b/TechPulse/Services/SemanticLinker.swift
@@ -104,6 +104,39 @@ enum SemanticLinker {
         store.vector(for: text)
     }
 
+    /// Embeds a batch of names away from whoever asked, handing back a table
+    /// of what each one means.
+    ///
+    /// `nonisolated` and `async`, so calling it from the main actor leaves it:
+    /// under Swift 6.0 a nonisolated async function runs on the generic
+    /// executor, and the caller suspends rather than spinning. Handing back a
+    /// whole table rather than making callers await a name at a time is what
+    /// lets the rules that consult it stay synchronous — `ConceptIndex.match`
+    /// has nowhere to await, and `HotTopics.candidates` weighs a lane of terms
+    /// against a whole map inside one pass.
+    ///
+    /// That is a language rule, not a promise this code makes, and adopting
+    /// `nonisolated(nonsending)` as the default would hand this loop back to
+    /// the caller's actor and #42 with it. The tests that would notice measure
+    /// main-actor time rather than how long the batch took —
+    /// `ConceptDedupeTests.preparingAnIndexDoesNotBlockTheMainActor` and
+    /// `HotCandidateTests.candidatesDoNotBlockTheMainActor`.
+    ///
+    /// A name the embedding cannot place is recorded as empty rather than left
+    /// out, so whoever holds the table does not attempt it again. `VectorStore`
+    /// does not remember a failure — it is a real answer about a language or a
+    /// device, not a miss — so without the empty entry the table would be
+    /// missing a key and its holder would ask the model afresh every lookup.
+    nonisolated static func meanings(
+        of names: [String],
+        using vector: @escaping @Sendable (String) -> [Double]?
+    ) async -> [String: [Double]] {
+        var meanings: [String: [Double]] = [:]
+        meanings.reserveCapacity(names.count)
+        for name in names { meanings[name] = vector(name) ?? [] }
+        return meanings
+    }
+
     /// The Semantic Links for one Pack's Concepts, strongest first.
     ///
     /// Cost is dominated by one embedding call per Concept (~6 ms); the

--- a/TechPulse/Views/FeedView.swift
+++ b/TechPulse/Views/FeedView.swift
@@ -17,6 +17,8 @@ struct FeedView: View {
     /// Offered in the 🔥 lane, where the reader is already looking at what the
     /// terms came from.
     @State private var candidates: [HotTerm] = []
+    /// The pass that fills `candidates`, kept so the next one can cancel it.
+    @State private var hotObservation: Task<Void, Never>?
     @State private var isSyncing = false
     @State private var searchText = ""
     // Atomic Habits: start tiny (3/day), make progress visible, reward completion.
@@ -64,10 +66,45 @@ struct FeedView: View {
         return hotTerms.contains(where: text.contains)
     }
 
+    /// The lane's vocabulary, and the offers that go beside it.
+    ///
+    /// Split across a suspension on purpose. `rising` tokenises Articles
+    /// already in memory and stays here, so the 🔥 filter has its terms the
+    /// moment the feed changes. `candidates` weighs each of them against the
+    /// whole map by meaning, which is two seconds of embedding on a large one —
+    /// and both of this method's callers hold the main actor: `task`, which
+    /// reaches here with nothing awaited in front of it on a launch where no
+    /// Article is pending analysis, and `onChange`, which cannot await at all.
+    /// So it is awaited in a `Task` rather than run here (#49).
+    ///
+    /// The strip is filled only when the whole pass has run. Showing what the
+    /// spelling check alone admits would put chips in front of the reader that
+    /// the meaning check is about to withdraw — the suppression is the point of
+    /// the offer, not a refinement of it. The offer already on screen is left
+    /// standing meanwhile rather than cleared: a sync arrives while the reader
+    /// is looking at the lane, and collapsing the strip on every one of them
+    /// would move the article list under their thumb to say nothing. What is
+    /// shown for that second is what a feed one sync older was rising toward,
+    /// which is where it came from anyway.
+    ///
+    /// A pass still in flight is cancelled, which drops its *result* rather
+    /// than its work — `HotTopics.candidates` has no cancellation check in it,
+    /// and the batch it is inside is one call. That is the whole of what the
+    /// cancellation is for: a sync landing mid-pass would otherwise race it,
+    /// and the older one finishing last would offer terms from a feed that has
+    /// moved on. The work it finishes anyway costs the next pass nothing, since
+    /// `SemanticLinker.embed` memoises across the launch.
     private func observeHotTerms() {
         let rising = HotTopics.rising(in: articles)
         hotTerms = rising.map(\.text)
-        candidates = HotTopics.candidates(from: rising, concepts: allConcepts)
+
+        let concepts = allConcepts
+        hotObservation?.cancel()
+        hotObservation = Task {
+            let offered = await HotTopics.candidates(from: rising, concepts: concepts)
+            guard !Task.isCancelled else { return }
+            candidates = offered
+        }
     }
 
     /// Day sections (design 2a): TODAY / YESTERDAY / explicit date.
@@ -422,6 +459,13 @@ struct FeedView: View {
                             // `allConcepts` is the array this body pass
                             // captured, and it does not refresh in time —
                             // asking again would offer the term just accepted.
+                            //
+                            // Any observation still in flight was started from
+                            // a map without this Concept on it, so letting it
+                            // land would put the chip back after the reader
+                            // took it. Cancelled for the same reason the line
+                            // below does not recompute.
+                            hotObservation?.cancel()
                             candidates.removeAll { $0.text == candidate.text }
                         }
                     } label: {

--- a/Tests/UnitTests/ConceptDedupeTests.swift
+++ b/Tests/UnitTests/ConceptDedupeTests.swift
@@ -43,32 +43,6 @@ struct ConceptDedupeTests {
         }
     }
 
-    /// Runs `work` and reports the longest the main actor went unserved while
-    /// it did — alongside how long it took, which is the number #42 is *not*
-    /// about. The work still costs what it costs; the question is who waits.
-    ///
-    /// The heartbeat is a task on the main actor that does nothing but yield.
-    /// Anything holding the main actor keeps it from being served, and the gap
-    /// it then records is what a reader would have seen as a frozen Feed.
-    private func mainActorStall<T>(during work: () async -> T)
-    async -> (value: T, stall: TimeInterval, elapsed: TimeInterval) {
-        let heartbeat = Task { @MainActor in
-            var longest: TimeInterval = 0
-            var last = Date.now
-            while !Task.isCancelled {
-                await Task.yield()
-                longest = max(longest, Date.now.timeIntervalSince(last))
-                last = .now
-            }
-            return longest
-        }
-        let started = Date.now
-        let value = await work()
-        let elapsed = Date.now.timeIntervalSince(started)
-        heartbeat.cancel()
-        return (value, await heartbeat.value, elapsed)
-    }
-
     private func index(_ concepts: [Concept],
                        sameIdea pair: Set<String> = []) -> ConceptIndex {
         ConceptIndex(concepts, vector: vectors(sameIdea: pair))

--- a/Tests/UnitTests/HotCandidateTests.swift
+++ b/Tests/UnitTests/HotCandidateTests.swift
@@ -36,23 +36,23 @@ struct HotCandidateTests {
     // MARK: What is offered
 
     @Test("a term with nothing like it on the map is a candidate")
-    func unmatchedTermIsOffered() {
-        let candidates = HotTopics.candidates(from: [term("world model")],
+    func unmatchedTermIsOffered() async {
+        let candidates = await HotTopics.candidates(from: [term("world model")],
                                               concepts: [concept("Attention")],
                                               vector: strangers)
         #expect(candidates.map(\.text) == ["world model"])
     }
 
     @Test("a term the map already has by name is not offered again")
-    func exactMatchIsNotOffered() {
-        let candidates = HotTopics.candidates(from: [term("world model")],
+    func exactMatchIsNotOffered() async {
+        let candidates = await HotTopics.candidates(from: [term("world model")],
                                               concepts: [concept("World Model")],
                                               vector: strangers)
         #expect(candidates.isEmpty, "matched on name, ignoring case")
     }
 
     @Test("a rising term the map does not mean is offered, judged by the real embedding")
-    func realEmbeddingStillOffersWhatIsGenuinelyNew() throws {
+    func realEmbeddingStillOffersWhatIsGenuinelyNew() async throws {
         // The other side of the threshold move (#41). Widening it from 0.25 to
         // 0.50 suppresses more, and what it must not suppress is the growth
         // this feature exists to catch. The real embedding, against the whole
@@ -65,20 +65,20 @@ struct HotCandidateTests {
                       "small models"]
 
         for text in rising {
-            let candidates = HotTopics.candidates(from: [term(text)], concepts: concepts)
+            let candidates = await HotTopics.candidates(from: [term(text)], concepts: concepts)
             #expect(candidates.map(\.text) == [text],
                     "“\(text)” was taken for something the map already has")
         }
     }
 
     @Test("a term the map already has, spelled another way, is not offered")
-    func foldedSpellingIsNotOffered() {
+    func foldedSpellingIsNotOffered() async {
         // The plural of a one-word name is further from it, under the
         // embedding, than two distinct ideas are (#41) — so this is the fold's
         // to catch, here as in `ConceptIndex.match`. Offering it would put a
         // chip in front of the reader that adds nothing when tapped: adopting
         // it merges straight back into the Concept they already have.
-        let candidates = HotTopics.candidates(from: [term("benchmarks"), term("kv cache")],
+        let candidates = await HotTopics.candidates(from: [term("benchmarks"), term("kv cache")],
                                               concepts: [concept("Benchmark"),
                                                          concept("KV-Cache")],
                                               vector: strangers)
@@ -86,20 +86,20 @@ struct HotCandidateTests {
     }
 
     @Test("a term the map already has inside a longer Concept name is not offered")
-    func containedNameIsNotOffered() {
-        let candidates = HotTopics.candidates(from: [term("world model")],
+    func containedNameIsNotOffered() async {
+        let candidates = await HotTopics.candidates(from: [term("world model")],
                                               concepts: [concept("World Model Research")],
                                               vector: strangers)
         #expect(candidates.isEmpty)
     }
 
     @Test("a term extending something on the map is still offered")
-    func extensionOfAKnownConceptIsOffered() {
+    func extensionOfAKnownConceptIsOffered() async {
         // The map has "Attention"; the field has started saying "attention
         // sinks". That is the growth this feature exists for, and suppressing
         // it because the shorter name is inside the longer one would silence
         // exactly the terms worth catching.
-        let candidates = HotTopics.candidates(from: [term("attention sinks")],
+        let candidates = await HotTopics.candidates(from: [term("attention sinks")],
                                               concepts: [concept("Attention")],
                                               vector: strangers)
         #expect(candidates.map(\.text) == ["attention sinks"])
@@ -118,11 +118,11 @@ struct HotCandidateTests {
     }
 
     @Test("a term the map already means, in other words, is not offered")
-    func meaningMatchIsNotOffered() {
+    func meaningMatchIsNotOffered() async {
         // "retrieval augmentation" and "RAG" are the same thing said twice.
         // The map has one; offering the other would be a duplicate the reader
         // has to notice is a duplicate.
-        let candidates = HotTopics.candidates(
+        let candidates = await HotTopics.candidates(
             from: [term("retrieval augmentation")], concepts: [concept("RAG")],
             vector: { name in
                 ["retrieval augmentation", "rag"].contains(name) ? [1, 0, 0] : [0, 1, 0]
@@ -131,12 +131,12 @@ struct HotCandidateTests {
     }
 
     @Test("a term merely near something on the map is still offered")
-    func distantMeaningIsStillOffered() {
+    func distantMeaningIsStillOffered() async {
         // The threshold is conservative on purpose: two Concepts stored
         // separately is a smaller harm than two ideas silently merged.
         // Pointing partly the same way — nearer than a stranger, further than
         // the same idea said twice.
-        let candidates = HotTopics.candidates(from: [term("world model")],
+        let candidates = await HotTopics.candidates(from: [term("world model")],
                                               concepts: [concept("RAG")],
                                               vector: { name in
                                                   name == "world model" ? [1, 1, 0] : [1, 0, 0]
@@ -145,18 +145,18 @@ struct HotCandidateTests {
     }
 
     @Test("the offer is bounded, because it is an invitation and not a backlog")
-    func offerIsBounded() {
+    func offerIsBounded() async {
         let terms = (0..<10).map { term("topic \($0)") }
-        #expect(HotTopics.candidates(from: terms, concepts: [], vector: strangers).count
-                <= HotTopics.candidateLimit)
+        let candidates = await HotTopics.candidates(from: terms, concepts: [], vector: strangers)
+        #expect(candidates.count <= HotTopics.candidateLimit)
     }
 
     // MARK: Only offered
 
     @Test("asking what the candidates are does not add any of them")
-    func candidatesAreNotAdded() throws {
+    func candidatesAreNotAdded() async throws {
         let context = try context()
-        _ = HotTopics.candidates(from: [term("world model")], concepts: [], vector: strangers)
+        _ = await HotTopics.candidates(from: [term("world model")], concepts: [], vector: strangers)
         #expect(try context.fetch(FetchDescriptor<Concept>()).isEmpty)
     }
 
@@ -221,11 +221,12 @@ struct HotCandidateTests {
         #expect(try context.fetch(FetchDescriptor<Concept>()).count == 1)
     }
 
-    @Test("offering candidates against a full map does not hold the Feed up")
-    func offerAgainstRealMapIsPrompt() throws {
+    @Test("offering candidates against a full map is prompt")
+    func offerAgainstRealMapIsPrompt() async throws {
         // The default path runs Apple's embedding, and the flagship Pack is 68
-        // Concepts — so a lane of eight terms is up to 544 comparisons, on the
-        // main actor, inside a view update.
+        // Concepts — so a lane of eight terms is up to 544 comparisons. Wall
+        // clock, deliberately: who waits for them is `candidatesDoNotBlockTheMainActor`'s
+        // question, and this one is that the work itself stayed small.
         let context = try context()
         try PackInstaller.install(try BuiltinPacks.aiEngineer(), origin: .builtin,
                                   context: context, vector: { _ in nil })
@@ -233,10 +234,48 @@ struct HotCandidateTests {
         let terms = (0..<HotTopics.laneSize).map { term("candidate topic \($0)") }
 
         let started = Date.now
-        _ = HotTopics.candidates(from: terms, concepts: concepts)
+        _ = await HotTopics.candidates(from: terms, concepts: concepts)
         let elapsed = Date.now.timeIntervalSince(started)
 
         #expect(elapsed < 1, "offering against \(concepts.count) Concepts took \(elapsed)s")
+    }
+
+    @Test("offering candidates against a large map does not freeze the Feed")
+    func candidatesDoNotBlockTheMainActor() async throws {
+        // The seam #49 names. Both of the Feed's callers reach the meaning
+        // check through here — `FeedView.task`, where `analyzePending` returns
+        // straight away on a launch with nothing pending and leaves the map
+        // unembedded, and `.onChange`, a synchronous view callback with
+        // nowhere to await at all — so main-actor time spent here is time the
+        // Feed is not drawn, whichever of them asked.
+        //
+        // The real embedding, at the map size #42 was measured from, and names
+        // unique to this test so the launch-long memo in `SemanticLinker.embed`
+        // is cold whichever order the suite runs in.
+        let context = try context()
+        let concepts = (0..<600).map { number -> Concept in
+            let idea = concept("Offered Idea \(number)")
+            context.insert(idea)
+            return idea
+        }
+        let rising = [term("quiet launch topic")]
+
+        let (offered, stall, elapsed) = await mainActorStall {
+            await HotTopics.candidates(from: rising, concepts: concepts)
+        }
+
+        #expect(elapsed > 0.5,
+                "the pass cost \(elapsed)s — 600 Concepts were not really embedded")
+        #expect(stall < elapsed / 5,
+                "the Feed was held for \(stall)s of the \(elapsed)s pass")
+        // Measured: 57 ms held, of a 2.2 s pass. The ratio is the claim; the
+        // absolute bar keeps a slow machine from passing on it, and bounds the
+        // work left behind on the main actor once the embedding hops off — the
+        // fold pass, and a distance per Concept per term, which at 600 Concepts
+        // is the arithmetic `SemanticLinker.distance` went through `vDSP` for.
+        #expect(stall < 0.25, "the Feed was held for \(stall)s")
+        // And the lane still answers: the map was weighed, not skipped.
+        #expect(offered.map(\.text) == ["quiet launch topic"])
     }
 
     @Test("an accepted candidate stops being offered")
@@ -244,7 +283,8 @@ struct HotCandidateTests {
         let context = try context()
         _ = await HotTopics.adopt(term("world model"), context: context)
         let concepts = try context.fetch(FetchDescriptor<Concept>())
-        #expect(HotTopics.candidates(from: [term("world model")], concepts: concepts,
-                                     vector: strangers).isEmpty)
+        let candidates = await HotTopics.candidates(from: [term("world model")],
+                                                    concepts: concepts, vector: strangers)
+        #expect(candidates.isEmpty)
     }
 }

--- a/Tests/UnitTests/MainActorStall.swift
+++ b/Tests/UnitTests/MainActorStall.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Runs `work` and reports the longest the main actor went unserved while it
+/// did — alongside how long it took, which is the number these tests are *not*
+/// about. The work still costs what it costs; the question is who waits.
+///
+/// The heartbeat is a task on the main actor that does nothing but yield.
+/// Anything holding the main actor keeps it from being served, and the gap it
+/// then records is what a reader would have seen as a frozen Feed.
+///
+/// Shared rather than owned by one suite: #42 asked this question of
+/// de-duplication and #49 asks it again of the 🔥 lane, at a different seam on
+/// the same screen. A second copy of the heartbeat would be a second thing to
+/// keep honest.
+@MainActor
+func mainActorStall<T>(during work: () async -> T)
+async -> (value: T, stall: TimeInterval, elapsed: TimeInterval) {
+    let heartbeat = Task { @MainActor in
+        var longest: TimeInterval = 0
+        var last = Date.now
+        while !Task.isCancelled {
+            await Task.yield()
+            longest = max(longest, Date.now.timeIntervalSince(last))
+            last = .now
+        }
+        return longest
+    }
+    // The heartbeat takes its first beat before the work starts. Without this
+    // it is only scheduled, and work that holds the main actor throughout —
+    // exactly the failure being measured — would run to completion before the
+    // heartbeat ever set its clock, and report no stall at all.
+    await Task.yield()
+    let started = Date.now
+    let value = await work()
+    let elapsed = Date.now.timeIntervalSince(started)
+    heartbeat.cancel()
+    return (value, await heartbeat.value, elapsed)
+}


### PR DESCRIPTION
Closes #49.

Stacked on #50 — based on `41-calibrate-the-de-duplication-threshold`, so this PR shows only its own commit. GitHub will retarget it to `main` when #50 merges.

## What was wrong

`HotTopics.candidates` judged whether a rising term was already on the map by meaning, and embedded every Concept name to do it — synchronously, on the main actor, from two places in `FeedView` that both hold it (`task` at line 125, `.onChange` at line 133). That is #42's two seconds again, on the same screen, in the same `task`.

#42 did not already cover it because the memo in `SemanticLinker.embed` is shared and keyed the same way both paths key it, so when analysis runs first the lane finds every vector already computed. But `analyzePending` early-returns when no Article is waiting for a summary — every launch where the reader is caught up — and `.onChange` never had analysis in front of it at all. The cost landed on the first rising term the map cannot name, which is the case the lane exists to catch.

## The shape

- `ConceptIndex.prepared`'s private `meanings` moves onto `SemanticLinker` as `meanings(of:using:)`, beside the `embed` it calls: one `nonisolated async` batch, two callers, handing back a table so both keep their rules synchronous.
- `candidates` folds spelling first, over names already in memory. A reader with nothing rising the map cannot name embeds nothing at all; what survives is embedded with the map in one batch, so a lane costs one suspension however long it is.
- Nothing consults the map's size. Making the lane smaller to dodge the cost is the shape of #11's 500-Concept ceiling.
- The Feed awaits the pass in a cancellable `Task`. `rising` stays synchronous, so the 🔥 filter has its vocabulary the moment the feed changes.

## Two judgement calls worth a look

**The strip is not filled from the spelling pass and then narrowed**, which is what the issue's "Suggested shape" floated. Suppression is the point of the offer, and the chips withdrawn would be exactly the duplicates it exists to keep off the screen — so it would fail "still suppresses what it suppressed" visibly for a second or two. The offer already on screen stays standing meanwhile rather than being cleared.

**Late assignment needed a second cancellation.** Accepting a chip drops it from `candidates` by hand (`allConcepts` does not refresh in time — the comment there predates this change), and a pass started before the adoption would land afterwards and put the chip back. Synchronous assignment used to make that ordering safe for free.

## The harness was under-measuring, and #42's numbers rested on it

`mainActorStall` started its heartbeat task and went straight into the work. Work that never yields runs to completion *before* the heartbeat's first beat, so it set its clock after the freeze and reported no stall at all — the new test passed against the unfixed code with the main actor frozen for 1.46 s.

One `await Task.yield()` between starting the heartbeat and starting the clock, and it failed honestly. **Both of #42's measurements still pass under the stricter harness**, which is the evidence that what they claimed was true and only their proof was thin. It is shared out of `ConceptDedupeTests` into `Tests/UnitTests/MainActorStall.swift` now, since two issues ask the same question at different seams.

## Verified

- `candidatesDoNotBlockTheMainActor` measures at the seam both callers reach: 600 Concepts named uniquely so the launch-long memo is cold whatever order the suite runs in, the real embedding, main-actor time rather than wall clock. **57 ms held of a 2.2 s pass, against 1.46 s before.** Absolute bar as well as the ratio, which is also what bounds the arithmetic left on the main actor after the embedding hops off.
- Every other assertion in `HotCandidateTests` is unchanged — the lane offers what it offered and suppresses what it suppressed. The eleven tests that called `candidates` synchronously now await it.
- 410 unit tests and all four UI journeys pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6k9KkbUUZKopxq69UJaCA