### PR TITLE
The journey read a button that had already gone (#48)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,51 @@
 
 ---
 
+## 2026-08-22 — The journey read a button that had already gone (#48)
+
+**Built**
+- **`Journey.label(of:)` — one snapshot, so "not there" is a value.**
+  `testCoreJourney` failed about one run in two, always at the topic-search
+  step, always with `Failed to get matching snapshot: No matches found…`. Not an
+  assertion: a *thrown query*, which is why it read as a broken journey rather
+  than a failing one and got shrugged at for as long as it did.
+- **The cause is that `exists` and `label` are two round trips to a live app.**
+  `!find.exists || find.label.contains("Added")` short-circuits, so `find.label`
+  runs only when `find.exists` just returned true — and the find-articles button
+  is removed the moment its Concept reaches three Articles, which is exactly
+  what the search that step just triggered is trying to make happen. Between the
+  two queries the button can go, and the second one has nothing to resolve.
+- **Three sites, not one.** The ticket named the poll condition. The line
+  *after* it does the same thing outside the poll, so it had no retry at all,
+  and the quiz step does it a third time. All three now read through the helper.
+
+**How it was found**
+
+A probe, before any theory: a UI test reading `.label` on a query that matches
+nothing. It reproduced the ticket's exact error in **6.9 seconds,
+deterministically** — against a journey that takes two minutes and fails half
+the time. Everything after that was mechanical. The probe also settled two facts
+the ticket did not state: `.label` **throws** rather than returning `""`, and
+`try? element.snapshot()` **is** catchable, which is not obvious given how much
+XCUITest reports outside the Swift error channel.
+
+**Verified** The regression pair runs in 12 s — one for the read that used to
+throw, one holding the helper to returning a real label for a control that is
+there, because a helper that answered nil for everything would make every wait
+built on it return true immediately and turn all four journeys silently green.
+Then `testCoreJourney` three consecutive times on the full UI suite: 122.9 s,
+124.2 s, 120.9 s, all passing. Worth stating plainly — at the observed failure
+rate, three passes in a row happen by luck about one time in eight. The
+deterministic pair is the proof; the three runs are corroboration.
+
+**Learned: the fix closes three call sites, not the hole.** `find.label` still
+compiles and still throws. `journey.waitUntil` takes `() -> Bool` and the caller
+closes over raw `XCUIElement`s — 51 such closures in the journeys, 8 of them
+reading element properties — so every author has to independently know the app
+may change between two reads. `Journey` owns polling, timeouts, screenshots and
+the ledger, then hands the hardest part back as a raw handle. Written up as a
+deepening opportunity rather than left in this entry.
+
 ## 2026-08-22 — Two taps on one chip made two Concepts (#42, found reviewing #50)
 
 **Built**

--- a/TechPulse.xcodeproj/project.pbxproj
+++ b/TechPulse.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		9A63C654F78898F6D8AC58E3 /* TechPulseWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0589963A0AE4B696E53ADA0C /* TechPulseWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		9FEFD5F2EBDE54F3A8D21D9D /* PackLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 571D5671CDF5C25BAA89D44C /* PackLibraryView.swift */; };
 		A12863526CABDA2078C6CC59 /* KeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24CB6AB829AE3904762AA2F3 /* KeychainStore.swift */; };
+		A670AB4B9F30C4AC36547A68 /* JourneyReadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFAE9B2F0337F35B7DA33022 /* JourneyReadTests.swift */; };
 		A92653B3045447F6CBC37F0A /* SeededReadingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDAA982C400CAC86FA1E110 /* SeededReadingTests.swift */; };
 		AC269276B3F82B7025C3E3FB /* UITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4891801E7DD9F1BA352978AC /* UITestSupport.swift */; };
 		AD3AF80B7D4B0DC6B5720FA4 /* PackFileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E37A1B81DE21F03EB89D165 /* PackFileTests.swift */; };
@@ -277,6 +278,7 @@
 		FC206139BB65D5F158F617F3 /* StreakWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreakWidget.swift; sourceTree = "<group>"; };
 		FC2344CCBC4508F65DBE94A4 /* SemanticLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SemanticLink.swift; sourceTree = "<group>"; };
 		FD06BF3A4AAACB4F2DCC8803 /* FullTextService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullTextService.swift; sourceTree = "<group>"; };
+		FFAE9B2F0337F35B7DA33022 /* JourneyReadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JourneyReadTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXGroup section */
@@ -326,6 +328,7 @@
 			isa = PBXGroup;
 			children = (
 				5E0AC48BA00E4E792E92DD6F /* Journey.swift */,
+				FFAE9B2F0337F35B7DA33022 /* JourneyReadTests.swift */,
 				EE45300FDDCED3CAA7416DFF /* TechPulseUITests.swift */,
 			);
 			name = UITests;
@@ -765,6 +768,7 @@
 			files = (
 				B43E70327381BAB77E06FB3D /* Journey.swift in Sources */,
 				3999C796E4420BAEE8E89466 /* JourneyLedger.swift in Sources */,
+				A670AB4B9F30C4AC36547A68 /* JourneyReadTests.swift in Sources */,
 				96315EB538495DDC2CEFAAF0 /* TechPulseUITests.swift in Sources */,
 				291AC0AD5362A7FD04FF36ED /* UITestLaunch.swift in Sources */,
 			);

--- a/Tests/UITests/Journey.swift
+++ b/Tests/UITests/Journey.swift
@@ -97,6 +97,27 @@ final class Journey {
         waitUntil(what, timeout: timeout, file: file, line: line) { !element.exists }
     }
 
+    /// What a control says, or nil if it is not there — read in **one** query.
+    ///
+    /// `exists` and `label` are two separate queries against a live app, and a
+    /// control that goes between them makes the second one throw rather than
+    /// answer: `Failed to get matching snapshot: No matches found…`, which is a
+    /// thrown query rather than a failed assertion, so it reads as a broken
+    /// journey rather than a false one. The find-articles button does exactly
+    /// that — it is removed the moment its Concept reaches three Articles,
+    /// which is what the search that step just triggered is trying to make
+    /// happen — and `testCoreJourney` failed about one run in two on it (#48).
+    ///
+    /// One snapshot, so "not there" is a value the caller can branch on.
+    /// `static` because reading a label needs nothing a journey holds; it is
+    /// here so it sits with the other ways this file reads a live app.
+    ///
+    /// Nil still means gone, exactly as `!exists` did — this narrows *when* the
+    /// question is asked, not what the answer means.
+    static func label(of element: XCUIElement) -> String? {
+        (try? element.snapshot())?.label
+    }
+
     /// Waits for anything else worth waiting for. `what` is the condition in
     /// words, and it is what the failure says.
     ///

--- a/Tests/UITests/JourneyReadTests.swift
+++ b/Tests/UITests/JourneyReadTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+
+/// How the journeys read a live app.
+///
+/// `Journey.label(of:)` exists because `exists` then `label` is two queries,
+/// and a control that goes between them makes the second one throw rather than
+/// answer — a thrown query, which reads as a broken journey rather than a
+/// failing one. `testCoreJourney` lost that race about one run in two (#48).
+@MainActor
+final class JourneyReadTests: XCTestCase {
+
+    /// The half that used to throw. Measured against a query that matches
+    /// nothing, which is the state a vanished control leaves behind: this is
+    /// the read the journey performs, at the moment it performs it.
+    func testLabelOfSomethingNotThereIsNilRatherThanAThrownQuery() {
+        let app = XCUIApplication()
+        app.launchArguments += [UITestLaunch.resetStore]
+        app.launch()
+
+        let gone = app.buttons["noSuchControlInThisApp"].firstMatch
+        XCTAssertFalse(gone.exists, "the fixture must name a control the app does not have")
+        // Reading `gone.label` here is what fails the suite with
+        // “Failed to get matching snapshot: No matches found…”.
+        XCTAssertNil(Journey.label(of: gone))
+    }
+
+    /// And the other half, so the helper cannot pass the test above by being
+    /// nil for everything — which would make every wait built on it return
+    /// true immediately and every journey silently green.
+    func testLabelOfSomethingPresentIsWhatItSays() {
+        let app = XCUIApplication()
+        app.launchArguments += [UITestLaunch.resetStore]
+        app.launch()
+
+        let onboarding = app.buttons["onboardingContinue"].firstMatch
+        XCTAssertTrue(onboarding.waitForExistence(timeout: 30),
+                      "a wiped store opens on onboarding")
+        let says = Journey.label(of: onboarding)
+        XCTAssertNotNil(says)
+        XCTAssertFalse(says?.isEmpty ?? true, "a button that is there says something")
+    }
+}

--- a/Tests/UITests/TechPulseUITests.swift
+++ b/Tests/UITests/TechPulseUITests.swift
@@ -187,9 +187,13 @@ final class TechPulseUITests: XCTestCase {
             // Waiting for it to merely *disable* would catch the search
             // starting, and screenshot the spinner.
             journey.waitUntil("the arXiv search never came back", timeout: 45) {
-                !find.exists || find.label.contains("Added") || find.label.contains("No new matches")
+                // Gone is an answer, and so is either result it reports. A
+                // search still running keeps the button and its spinner, so
+                // this still times out loudly when nothing comes back.
+                guard let says = Journey.label(of: find) else { return true }
+                return says.contains("Added") || says.contains("No new matches")
             }
-            foundNothing = find.exists && find.label.contains("No new matches")
+            foundNothing = Journey.label(of: find)?.contains("No new matches") ?? false
             journey.snap("5b2b-topic-search")
         }
         if !foundNothing {
@@ -371,7 +375,9 @@ final class TechPulseUITests: XCTestCase {
             }
             action.tap()                                   // check answer
             journey.waitUntil("question \(answered + 1) never showed whether the answer was right") {
-                !action.exists || action.label != "Check answer"
+                // Gone or relabelled, read in one query — the same race
+                // the find-articles button lost (#48).
+                Journey.label(of: action) != "Check answer"
             }
             journey.tap(action, "the way on from question \(answered + 1)")
             answered += 1


### PR DESCRIPTION
Closes #48.

## The race

`exists` and `label` are two round trips to a live app:

```swift
!find.exists || find.label.contains("Added") || find.label.contains("No new matches")
```

`||` short-circuits, so `find.label` runs only when `find.exists` has just returned true — and the find-articles button is removed the moment its Concept reaches three Articles, which is exactly what the search that step just triggered is trying to make happen. Between the two queries the button can go, and the second one has nothing left to resolve against.

The result is a **thrown query**, not a failed assertion, which is why `testCoreJourney` failing about one run in two read as a broken journey rather than a failing one.

## The fix

`Journey.label(of:)` — `(try? element.snapshot())?.label` — one query, so "not there" is a value the caller branches on. Nil still means gone, exactly as `!exists` did: this narrows *when* the question is asked, not what the answer means. The 45-second timeout assertion is untouched, so a search that genuinely never returns still fails loudly.

**Three sites, not one.** The ticket named the poll condition; the line immediately after it does the same thing *outside* the poll, so it had no retry at all, and the quiz step does it a third time. `grep` for `.label`/`.value` beside `.exists` now comes back empty.

## Loop before theory

A probe reading `.label` on a query matching nothing reproduced the exact error in **6.9 s, deterministically** — against a journey that takes two minutes and fails half the time. It settled two facts the ticket did not state:

- `.label` **throws**; it does not return `""`.
- `try? element.snapshot()` **is** catchable — not obvious, given how much XCUITest reports outside the Swift error channel.

## Verification

- `JourneyReadTests`, 12 s for the pair: one for the read that used to throw, one holding the helper to returning a real label for a control that *is* there — a helper that answered nil for everything would make every wait built on it return true immediately and turn all four journeys silently green.
- `testCoreJourney` three consecutive times on the full UI suite: **122.9 s, 124.2 s, 120.9 s, all passing**, with no thrown-query lines. (Failing runs used to die early at ~50 s.)
- 411 unit tests still pass.

At the observed failure rate, three passes in a row happen by luck about one time in eight — so the deterministic pair is the proof and the three runs are corroboration, not the other way round.

## What this does not fix

Three call sites, not the hole. `find.label` still compiles and still throws; `journey.waitUntil` takes `() -> Bool` and callers close over raw `XCUIElement`s. Filed separately as a deepening opportunity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6k9KkbUUZKopxq69UJaCA