### PR TITLE
A wait is handed what a control said, not the control (#53)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,6 +28,11 @@ _Avoid_: domain, subject, topic, area, pack name
 Where a Pack came from: the app itself, a file the reader was given, or
 generation. Reader-visible, and what tells two Packs apart when they cover the
 same field.
+
+A Pack has an Origin; a Source does not. How a Source was acquired — suggested
+by a Pack and accepted, or typed in — is not recorded and nothing branches on
+it: once subscribed, a Source is the reader's, and the app treats every one of
+them alike.
 _Avoid_: source (a Source is a place reading arrives from), kind, provenance
 
 **Built-in Pack**:
@@ -121,7 +126,17 @@ end, and to how that end decided what to put there. What a Source is ordered by
 is part of what you subscribed to: subscribe to a popularity-ranked one and
 community attention reaches your reading without the app ever learning that
 popularity exists.
-_Avoid_: feed, channel, subscription, publisher
+
+**Acquired** is how a Source comes to be one, and "chosen" is literal at every
+step but one. A Pack **suggests** Sources; the app **offers** them; the reader
+subscribes. The exception is the first launch of a store with nothing to read at
+all, which subscribes to what the Active Pack suggests — there is no reading yet
+to weigh an offer against. Every launch after that subscribes to nothing: a
+Source added to a Pack in a new version of the app is acquired as a **standing
+offer** in Settings, and waits there. A suggestion the reader turns down is not
+raised again unless they install that Pack themselves. See ADR-0011.
+_Avoid_: feed, channel, subscription, publisher; and, for what a Pack puts in
+front of a reader, **default Source** — the app has no Sources of its own
 
 **Reading Intention**:
 The user's own stated plan for when reading happens — a time, and the existing

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,62 @@
 
 ---
 
+## 2026-08-22 — An imported Pack can suggest unlimited Sources (#20)
+
+**Built**
+- **`PackFile.maxSuggestedSources`, 30, checked by `PackValidator`.** The
+  validator already bounded a Pack's Concepts (120), Clusters (10) and
+  Dependencies per Concept (8), and put no bound at all on `suggestedSources`.
+  An import is a file from outside the app, so the format is where it is told
+  no: a Pack carrying 500 suggestions is now rejected as
+  `tooManySuggestedSources`, in the same voice as the other thirteen reasons.
+- **Thirty because that is the whole day's reading.** `FeedSyncService`
+  shares `dailyIntakeLimit` — 30 articles — round-robin between the Sources the
+  reader has (ADR-0009), so a Pack suggesting more Sources than the day has
+  articles is suggesting Sources that cannot all be heard even once. The
+  built-in Packs suggest 14 and 13, so this is a bound on the absurd rather
+  than a budget an author works inside. The number is *not* read from
+  `FeedSyncService`: the validator is pure by construction, with no store, no
+  network and no main actor in reach. The reasoning is what the two share.
+- **Rejected before the record, not at the sheet.** Capping at the offer would
+  have been too late — reaching the sheet at all means the suggestions are
+  already on the installed record, and `PackSourceOffer.standing` would raise
+  them at every launch from then on (#47). The guard sits beside the Cluster
+  count, so an over-cap Pack changes nothing about the map.
+- **Pre-checking is bounded too — `PackSourceOfferView.preCheckedUpTo`, 15.**
+  The sheet opened with every suggestion ticked, whatever the length, so "Add
+  500" was one tap. Pre-checking is consent by default and is honest only while
+  the reader can see what they are agreeing to. All-or-nothing rather than the
+  first fifteen: which suggestions a Pack listed first is the author's
+  ordering, not a ranking the app may read as consent.
+
+**Verified** 433 unit tests, ten new, plus `testPackSelectionJourney` and
+`testStandingSourceOfferJourney` — both tap "Add" without ticking anything, so
+both would have failed had the threshold landed under the built-ins' 14. The
+fan-out is asserted at the worst case the cap allows: thirty Sources, each on a
+host of its own so `HostPacing` helps as little as it ever can, and
+`StubTransport.peakConcurrency(among:)` gained a list-taking overload to ask
+about thirty hosts at once.
+
+**Learned: the issue's own diagnosis was one commit stale.** It described
+`syncAll` as adding "one task per source to an unbounded `withTaskGroup`". That
+was true when it was filed; #44 had since regrouped the fan-out by host, so it
+is one task per *host*. The bug survived the correction — 500 suggestions still
+buy up to 500 hosts — but the fix landed as a cap on the format rather than a
+limiter on the task group, because the number of requests a sync opens is
+bounded by how many Sources a reader can end up with, and that is a question
+about what a Pack may ask for.
+
+**Learned: a threshold set from the shipped Packs has to keep holding them.**
+`preCheckedUpTo` is 15 because the built-ins suggest 14 and 13 — the largest
+list the app itself vouches for. That makes the number quietly load-bearing for
+two UI journeys, which tap Add on a sheet they never ticked. So it is pinned by
+a test that walks `BuiltinPacks.all` and asserts each one's offer still opens
+ticked: a built-in that grows past the threshold now fails in a second rather
+than in a journey.
+
+---
+
 ## 2026-08-22 — A Source is offered, not delivered (#47)
 
 **Built**

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,89 @@
 
 ---
 
+## 2026-08-22 — A wait is handed what a control said, not the control (#53)
+
+**Built**
+- **`journey.waitUntil` takes the element as a parameter and hands the condition
+  an `ElementState?`.** #48 closed three call sites that were reading a control
+  twice; it closed nothing structurally, because `find.label` still compiled and
+  the next wait anyone wrote was one keystroke from the same thrown query. The
+  condition is now given one reading — `label`, `isEnabled`, `isSelected`, taken
+  in a single snapshot — and holds no element to ask a second question of.
+- **Existence is the optional, not a field.** The ticket sketched `exists` as a
+  third attribute; a control that has gone has no snapshot to report, so `nil`
+  carries that meaning already, in the one place a condition can still see it.
+  `waitUntilGone` is now one line of the new wait: `{ $0 == nil }`.
+- **The raw `() -> Bool` wait is gone, which is what makes this a seam rather
+  than a helper.** Every condition in the journeys turned out to be about
+  exactly one control, so nothing needed the old form — and with it deleted
+  there is nowhere left to write the two-query shape. `becomesTrue` went the
+  same way, replaced by `appears(_:within:)` for the four soft existence checks
+  that used it. `Journey`'s own `poll` stays private.
+- **Thirteen call sites converted**, nine of which read an attribute: four tab
+  `isSelected` waits, the "I know this" and quiz `isEnabled` waits, the two
+  find-articles label reads and the quiz's. The feed's sync-banner wait turned
+  out to be a `waitUntilGone` wearing a closure.
+
+- **Three assertions outside a wait converted too.** `continueButton.isEnabled`,
+  `know.isEnabled` and `start.isEnabled` each read a property of a control the
+  journey had merely waited for, so a control that went in between made them
+  *throw* rather than fail — the same reading-as-broken-rather-than-false shape,
+  outside the seam that now prevents it. They go through `Journey.state(of:)`.
+  What is left is two `isHittable` reads, which nothing can fold: XCUITest does
+  not carry hittability on a snapshot, so it cannot be read in the same query as
+  the rest and would be a second round trip wearing `ElementState`'s clothes.
+  It is off the type by design, and polled inside `Journey.tap`.
+- **`waitUntilGone` asks the element, not the snapshot** — caught in review, and
+  the one real bug this change introduced. Rewriting it as `{ $0 == nil }` on
+  the new wait was tidy and wrong: `try?` swallows *every* snapshot failure, not
+  just "no matches", so an app too busy to answer would have read as *dismissed*
+  and passed. An assertion that passes when something is gone must not pass on
+  silence. Presence now goes through one private `waitForPresence`, which asks
+  `exists` — a query that answers false rather than failing, so it tells absence
+  from silence — and `waitUntilGone`, `appears` and `tap` all share it.
+
+**Verified** The read tests grew from two to four and run in 21 s: the read that
+used to throw, the read that holds it to answering honestly for a control that
+is there, and now both halves of the wait — that a vanished control arrives as
+`nil` and a present one arrives with its attributes. Then the full suite: 436
+unit tests in 23 s, and all five journeys. The tab waits were the conversion
+worth doubting, since `isSelected` had only ever been read off the element — the
+dismissal guard was run on its own first to settle that a snapshot reports it
+the same way.
+
+`testCoreJourney` also **priced the bug the review caught**. With `waitUntilGone`
+polling a snapshot it ran 135.1 s and then 134.9 s alone, against the 120.9 –
+124.2 s #48 recorded on this machine; with it back on `exists` it is 123.7 s.
+A snapshot is a materially heavier query than `exists`, and eight dismissal
+waits polling one every 200 ms cost about eleven seconds a run. That was visible
+as a number before it was understood as a defect, and it was read as network
+variance in the arXiv step — worth remembering, because the honest fix and the
+faster run turned out to be the same edit.
+
+**Learned: "51 closures, 8 of them reading properties" was the wrong count to
+design against.** The number that mattered was that **every** condition in the
+journeys was about a single control — which is what let the raw form be deleted
+rather than merely discouraged. That was not knowable from the ticket, and it is
+the whole difference between this and the lint alternative it weighed: a lint
+catches the two-query shape where it looks for it, whereas a wait that never
+offered the shape catches it everywhere, including in the code nobody has
+written yet. The lint was never prototyped, and did not need to be: the survey
+is what made the structural close free, and a lint would have cost a tool, a
+config and a rule that only ever catches the spellings it was taught. Worth
+checking for on the next deepening — the cheap structural close is often hiding
+in a call-site survey the ticket did not do.
+
+**Learned: the tidy rewrite is where the bug went.** Every converted condition
+was semantically checked and correct. The defect was in the one call the ticket
+never mentioned — `waitUntilGone`, rewritten on the new seam because it *could*
+be, which quietly swapped a question that answers false for one that can fail
+silently. Both review axes found it independently, which is the argument for
+running them: it was invisible from inside the change, where the line reads as
+the seam finally paying off.
+
+---
+
 ## 2026-08-22 — The bound on pre-ticking made silence mean no (#20, follow-up)
 
 **Built**

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,64 @@
 
 ---
 
+## 2026-08-22 — The bound on pre-ticking made silence mean no (#20, follow-up)
+
+**Built**
+- **An unticked box is an answer only where the box arrived ticked.** #20 stopped
+  pre-ticking offers past `PackSourceOffer.preCheckedUpTo` and did not touch the
+  Add button, which records every unticked suggestion as declined. Those two are
+  only compatible while the sheet arrives pre-ticked — ADR-0011 says so in as
+  many words, and the premise is exactly what #20 removed. So a reader who ticked
+  three of thirty-one silently declined the other twenty-eight, close to
+  permanently, on a list they were never shown as ticked. `PackSourceOffer.accept`
+  now records declines only when `opensTicked` was true; otherwise the leftovers
+  stay in the standing offer, which is what unanswered is for. "Not now" still
+  refuses the lot.
+- **The consent policy moved off the View.** `preCheckedUpTo`, `opensTicked`,
+  `preChecked` and the new `accept` all sit on `PackSourceOffer`, whose header
+  already claimed that ground — "what is worth offering, what happens once the
+  reader says yes, and what happens once they say no". Subscribing and recording
+  a refusal are one call now, so no caller can apply half the rule.
+- **ADR-0011's consequence amended in place, with a correction note.** It read
+  "An unchecked box counts as an answer, **in both flows**" — an absolute that
+  stopped being true. `docs/agents/domain.md` warns about exactly this: "'No X'
+  is the sentence that gets restated without its exception."
+- **The ADR-0009 derivation was wrong and is gone.** `maxSuggestedSources`
+  claimed to be 30 "because that is `FeedSyncService.dailyIntakeLimit`". ADR-0009
+  says the opposite — "round-robin needs no per-Source constant, so nothing here
+  binds to how many Sources a Pack ships" — and calls that cap a habit decision
+  free to move for habit reasons. The number stands on its own footing: twice the
+  largest list the app itself ships. The agreement is now named as a coincidence.
+- **The fan-out test could not fail.** It asserted `peakConcurrency <= 30` over
+  thirty Sources on thirty hosts, which arithmetic guarantees; it would have
+  passed against any implementation, and against a cap of 500. Replaced with
+  thirty Sources over *ten* hosts asserting peak ≤ 10 — the property #44 actually
+  established, and one that breaks when grouping does.
+
+**Verified** 436 unit tests and both offer-sheet journeys. Both new claims were
+checked by breaking the thing they protect: grouping by URL instead of host takes
+the fan-out test to `peakConcurrency → 30` against a bound of 10, and restoring
+the unconditional `recordDeclined` fails the consent test with fifteen Sources
+buried. The old fan-out assertion passes under the first of those, which is the
+point.
+
+**Learned: a two-axis review earns its keep on the axis you think you own.**
+This was self-review-proof territory — I had written the pre-check threshold,
+tested it, and described it in a commit message and an issue comment as the
+careful half of the change. The Standards agent found it by reading ADR-0011's
+consequence against the diff, which is the one thing a self-review cannot do,
+because the author already believes the ADR says what they remember it saying.
+The Spec agent independently flagged the tautological test. Neither finding was
+about the cap the ticket asked for; both were about what the change quietly
+assumed.
+
+**Learned: bounding consent is not the same as withholding it.** The fix for
+"one tap subscribes thirty" was to stop pre-ticking, and pre-ticking turned out
+to be load-bearing for a rule two files away. Removing a default is never only
+removing a default — something downstream was reading it as a signal.
+
+---
+
 ## 2026-08-22 — An imported Pack can suggest unlimited Sources (#20)
 
 **Built**

--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,75 @@
 
 ---
 
+## 2026-08-22 — A Source is offered, not delivered (#47)
+
+**Built**
+- **`SeedData.defaultSources` is gone, and with it the second list.** The
+  flagship's Sources lived in `ai-engineer.json` *and* in a compiled array, and
+  only the array reached anybody: the offer fires when a reader installs a Pack
+  from the library by hand, not on the launch-time reinstall a
+  `builtinPackVersion` bump triggers. #46 had to add its Source to both. Now
+  suggestions are read off `ActivePack.inUse.suggestedSources` — the installed
+  record — so there is one list, and the Pack file owns it.
+- **Launch stopped subscribing.** `seedIfNeeded` used to insert any default the
+  store lacked, on every launch, "so app updates deliver new feeds to existing
+  installs". It cost consent twice over: the Source arrived unasked, *and*
+  because `PackSourceOffer.pending` filters out what is already subscribed, its
+  arrival suppressed the offer for it permanently. The gap closed itself.
+  `acquireSourcesIfNeeded` now subscribes only on a store with nothing to read
+  at all.
+- **A standing offer, in Settings.** Everything after the first launch arrives
+  as `PackSourceOffer.standing` — suggestions neither subscribed nor turned
+  down — surfaced as a row that opens the `PackSourceOfferView` the library
+  already used. Declines are recorded in `UserDefaults`, next to
+  `ActivePackIdentity`, because a decline is about what the reader was *asked*,
+  not about what their map holds.
+- **The seeder reads the Pack the reader is on.** It never did: `defaultSources`
+  was the AI list unconditionally, so a Security Engineering reader received
+  arXiv cs.AI, OpenAI News and r/kaggle. That meant reordering `seedIfNeeded` —
+  `ensureBuiltinInstalled` settles which Pack is active, so acquiring Sources
+  has to run after it, not before.
+- **`KnowledgePack.suggestedSources` keeps the pin and delivers nothing.** The
+  compiled list survives beside `concepts` and `stages` as the fixture
+  `BuiltinPacksTests` compares the Pack file against. What made #46 subtle was
+  not the duplication — it was that one copy was also the delivery path.
+
+- **A decline had to be forgettable by a store wipe.** `UITestSupport.resetStore`
+  promises a wipe leaves "exactly as a fresh install ... remembers nothing
+  anywhere", and keeps a list of the `UserDefaults` keys a store wipe cannot
+  reach. `declinedSourceSuggestions` is exactly such a key and was missing from
+  it, so a journey that declined an offer would have poisoned the next one's
+  fresh install. Found by the standards review, not by a failing test — which is
+  the point of that list existing.
+
+**Verified** 423 unit tests, twelve new, and all seven UI journeys — including
+`testStandingSourceOfferJourney`, added because the Settings row is the *only*
+surface the offer has, and it had none. It leaves the offer unanswered by
+dismissing the sheet rather than tapping either button, which is the one state
+that puts a suggestion in neither list; run four times for the swipe. The two
+consent tests were checked against the old behaviour by restoring the
+unconditional insert: both fail, and the pack-switch test reports a reader
+holding all 27 Sources from both Packs.
+
+**Learned: the offer was already correct, and was being outvoted.**
+`PackSourceOffer` said "Nothing is subscribed until you say so" and meant it;
+`PackInstaller` subscribed to nothing on purpose. Neither was wrong. The
+mechanism that actually reached readers was a third one that predated both and
+had never been reconciled with them — and the tell was in the tests, where
+`voteRankedSourceIsSeeded` existed only to assert that a Source was in *the
+other* list. A test whose reason for existing is that two lists must agree is a
+question about which one is real.
+
+**Learned: the first-launch exception wanted to be measured before the sweep.**
+Retiring a dead Source and deciding "has this reader had a first launch" are one
+line apart, and counting what is *left* after the sweep quietly reopened the
+first launch for a store the sweep had emptied — re-subscribing fourteen Sources
+to a reader who was never offered them, the exact behaviour being removed. The
+spec review caught it against the ADR's own consequences. Counting before the
+sweep is both simpler and right.
+
+---
+
 ## 2026-08-22 — The journey read a button that had already gone (#48)
 
 **Built**

--- a/TechPulse.xcodeproj/project.pbxproj
+++ b/TechPulse.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		55C48AE6CB76FD8C4B1ADA6A /* FeedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21E4491DBD576D7C3A194CF7 /* FeedView.swift */; };
 		589977A315079BD373EB3AF2 /* ExplainRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = A73F8F8DB42B31687E24BEDE /* ExplainRoute.swift */; };
 		5CFCE9E2620A771B439CA427 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805E262401FAC71EF8B36A16 /* OnboardingView.swift */; };
+		60721E7B574B899900CD070B /* SourceAcquisitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32A3A353D742382C897F7398 /* SourceAcquisitionTests.swift */; };
 		6AB8436080975FE2867EBB47 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B07EE9C61977870716F7F9E /* Theme.swift */; };
 		6BCBB97EDD258341FD8BF586 /* CoreadScoring.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9AE706BA6F2E2DA1455EF3C /* CoreadScoring.swift */; };
 		6DFDE1DEEC1F113933A40FF6 /* WeeklyLearningIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0794BD56A9EDCCBA857486 /* WeeklyLearningIntent.swift */; };
@@ -187,6 +188,7 @@
 		2E37A1B81DE21F03EB89D165 /* PackFileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackFileTests.swift; sourceTree = "<group>"; };
 		30BF4B81619B7930D334EA1C /* MainActorStall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainActorStall.swift; sourceTree = "<group>"; };
 		3217DDB8C0FCEF782C439924 /* KnowledgeEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeEngineTests.swift; sourceTree = "<group>"; };
+		32A3A353D742382C897F7398 /* SourceAcquisitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceAcquisitionTests.swift; sourceTree = "<group>"; };
 		32AFBF580D137E09E6248B83 /* TechPulseWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TechPulseWidget.entitlements; sourceTree = "<group>"; };
 		3622BA0341099C2B7B34C775 /* TechPulseWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TechPulseWidgetBundle.swift; sourceTree = "<group>"; };
 		366F07A6ACC8138673869DD7 /* ai-engineer.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "ai-engineer.json"; sourceTree = "<group>"; };
@@ -390,6 +392,7 @@
 				3888CD6831CCA2655369901B /* RSSParserTests.swift */,
 				6BDAA982C400CAC86FA1E110 /* SeededReadingTests.swift */,
 				01130D5542466DB13D5E9BEA /* SemanticLinkerTests.swift */,
+				32A3A353D742382C897F7398 /* SourceAcquisitionTests.swift */,
 				F7F93D2B29F3C7C5529B05FD /* StubTransport.swift */,
 				DDA6B7E14E098F5F1DEB3C57 /* StubTransportTests.swift */,
 				F1C1E4844F48EA3BC9B6F3A3 /* TopicSearchTests.swift */,
@@ -670,6 +673,7 @@
 				C61784038E077262EF1F2A15 /* ResponseLimitTests.swift in Sources */,
 				A92653B3045447F6CBC37F0A /* SeededReadingTests.swift in Sources */,
 				DABD57C8D910FBCA10AD84FD /* SemanticLinkerTests.swift in Sources */,
+				60721E7B574B899900CD070B /* SourceAcquisitionTests.swift in Sources */,
 				ADB09513CF9CF047AF2EC7FE /* StubTransport.swift in Sources */,
 				BB9B63803055DCB5A3BFDADB /* StubTransportTests.swift in Sources */,
 				1E177F824E7AD32EE4346C8B /* TopicSearchTests.swift in Sources */,

--- a/TechPulse/Services/KnowledgePack.swift
+++ b/TechPulse/Services/KnowledgePack.swift
@@ -25,6 +25,37 @@ enum KnowledgePack {
     /// The app's specialty lane, shown as a full-width card.
     static let specialtyCluster = "On-Device AI"
 
+    /// The flagship's suggested Sources, as compiled Swift.
+    ///
+    /// A fixture, like `concepts` and `stages` above it, and nothing reads it
+    /// at runtime: `ai-engineer.json` is what reaches a reader, and
+    /// `BuiltinPacksTests` compares the two so the conversion cannot silently
+    /// drop one. It used to be `SeedData.defaultSources`, which both pinned the
+    /// file *and* delivered Sources on every launch — one list that a Pack file
+    /// and a compiled array both claimed to own, which is what made #46 subtle
+    /// (#47).
+    static let suggestedSources: [(name: String, url: String, category: String)] = [
+        ("arXiv cs.AI", "https://export.arxiv.org/rss/cs.AI", "Research"),
+        ("arXiv cs.LG", "https://export.arxiv.org/rss/cs.LG", "Research"),
+        ("arXiv cs.CL", "https://export.arxiv.org/rss/cs.CL", "Research"),
+        ("Apple ML Research", "https://machinelearning.apple.com/rss.xml", "Research"),
+        ("Hugging Face Blog", "https://huggingface.co/blog/feed.xml", "Open Source"),
+        // Vote-ranked, which is the whole point of it: what a Source is ordered
+        // by is part of what you subscribed to, so community attention reaches
+        // the 🔥 lane without the app ever learning that popularity exists
+        // (ADR-0003, #46). One such Source, not several — they share a host,
+        // so they would share a queue (#44).
+        ("r/MachineLearning (top this week)", "https://www.reddit.com/r/MachineLearning/top/.rss?t=week", "LLMs"),
+        ("OpenAI News", "https://openai.com/news/rss.xml", "Frontier Labs"),
+        ("Google DeepMind Blog", "https://deepmind.google/blog/rss.xml", "Frontier Labs"),
+        ("MIT Technology Review — AI", "https://www.technologyreview.com/topic/artificial-intelligence/feed", "Industry"),
+        ("The Verge — AI", "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml", "Industry"),
+        ("VentureBeat — AI", "https://venturebeat.com/category/ai/feed/", "Industry"),
+        ("TechCrunch — AI", "https://techcrunch.com/category/artificial-intelligence/feed/", "Industry"),
+        ("Kaggle (r/kaggle)", "https://www.reddit.com/r/kaggle/.rss", "Data Science"),
+        ("KDnuggets", "https://www.kdnuggets.com/feed", "Data Science"),
+    ]
+
     struct PackConcept {
         let name: String
         let cluster: String
@@ -312,7 +343,7 @@ extension ActivePack {
             stages: KnowledgePack.stages.map {
                 .init(title: $0.title, subtitle: $0.subtitle, concepts: $0.conceptNames)
             },
-            suggestedSources: SeedData.defaultSources.map {
+            suggestedSources: KnowledgePack.suggestedSources.map {
                 .init(name: $0.name, url: $0.url, category: $0.category)
             },
             conceptNames: KnowledgePack.concepts.map(\.name),

--- a/TechPulse/Services/PackFile.swift
+++ b/TechPulse/Services/PackFile.swift
@@ -50,17 +50,21 @@ struct PackFile: Codable, Equatable {
 
     /// The most Sources a Pack may suggest.
     ///
-    /// Thirty because that is `FeedSyncService.dailyIntakeLimit` — the whole
-    /// day's reading, shared round-robin between the Sources the reader has
-    /// (ADR-0009). A Pack suggesting more Sources than the day has articles is
-    /// suggesting Sources that cannot all be heard even once, and every one of
-    /// them is a request the reader's device makes on a cold sync. The built-in
-    /// Packs suggest 14 and 13, so this is a bound on the absurd rather than a
-    /// budget an author has to work inside.
+    /// Thirty is a bound on the absurd, not a budget: the built-in Packs suggest
+    /// 14 and 13, so twice the largest list the app itself vouches for leaves an
+    /// author room the shipped Packs do not use. What it is there to stop is a
+    /// file from outside the app arriving with five hundred, because every
+    /// suggestion the reader accepts is a Source, and every Source is a request
+    /// their device makes on a cold sync.
     ///
-    /// Not read from `FeedSyncService`: this is the format's number, checked
-    /// off the main actor with no store or network in reach, and the two are
-    /// free to part company. The reasoning is what they share.
+    /// Deliberately *not* derived from `FeedSyncService.dailyIntakeLimit`, which
+    /// is also 30. ADR-0009 settles that the day's intake is shared round-robin
+    /// and says in as many words that "round-robin needs no per-Source constant,
+    /// so nothing here binds to how many Sources a Pack ships" — a Pack with
+    /// three and a Pack with thirty both get a defensible allocation. That cap
+    /// is a habit decision and is free to move for habit reasons; this one must
+    /// not move with it. The two numbers agreeing today is a coincidence worth
+    /// naming so that nobody reads it as a derivation.
     static let maxSuggestedSources = 30
 
     var formatVersion: Int = PackFile.currentFormatVersion

--- a/TechPulse/Services/PackFile.swift
+++ b/TechPulse/Services/PackFile.swift
@@ -48,6 +48,21 @@ struct PackFile: Codable, Equatable {
     static let maxClusters = 10
     static let maxDependenciesPerConcept = 8
 
+    /// The most Sources a Pack may suggest.
+    ///
+    /// Thirty because that is `FeedSyncService.dailyIntakeLimit` — the whole
+    /// day's reading, shared round-robin between the Sources the reader has
+    /// (ADR-0009). A Pack suggesting more Sources than the day has articles is
+    /// suggesting Sources that cannot all be heard even once, and every one of
+    /// them is a request the reader's device makes on a cold sync. The built-in
+    /// Packs suggest 14 and 13, so this is a bound on the absurd rather than a
+    /// budget an author has to work inside.
+    ///
+    /// Not read from `FeedSyncService`: this is the format's number, checked
+    /// off the main actor with no store or network in reach, and the two are
+    /// free to part company. The reasoning is what they share.
+    static let maxSuggestedSources = 30
+
     var formatVersion: Int = PackFile.currentFormatVersion
     /// What the map covers — "AI Engineering", "Data Science".
     var field: String
@@ -69,6 +84,7 @@ enum PackValidationError: LocalizedError, Equatable {
     case noConcepts
     case tooManyConcepts(Int)
     case badClusterCount(Int)
+    case tooManySuggestedSources(Int)
     case emptyDefinition(String)
     /// Two Concepts the installer would treat as one. Both spellings are
     /// carried: where they differ only in case, naming one of them sends the
@@ -92,6 +108,8 @@ enum PackValidationError: LocalizedError, Equatable {
             "Too many concepts (\(count) > \(PackFile.maxConcepts))."
         case .badClusterCount(let count):
             "Packs need 1–\(PackFile.maxClusters) clusters (got \(count))."
+        case .tooManySuggestedSources(let count):
+            "Too many suggested sources (\(count) > \(PackFile.maxSuggestedSources))."
         case .emptyDefinition(let name):
             "Concept “\(name)” has no definition."
         case .duplicateConcept(let first, let second) where first == second:
@@ -155,6 +173,13 @@ enum PackValidator {
         }
         guard (1...PackFile.maxClusters).contains(pack.clusterOrder.count) else {
             throw PackValidationError.badClusterCount(pack.clusterOrder.count)
+        }
+        // Checked here rather than at the offer: an import is a file from
+        // outside the app, so the format is where it is told no. Reaching the
+        // sheet at all would mean the Sources were already installed on the
+        // record, and every later launch would raise them as a standing offer.
+        guard pack.suggestedSources.count <= PackFile.maxSuggestedSources else {
+            throw PackValidationError.tooManySuggestedSources(pack.suggestedSources.count)
         }
 
         // Names must be unique before anything indexes by them — a duplicate

--- a/TechPulse/Services/PackSourceOffer.swift
+++ b/TechPulse/Services/PackSourceOffer.swift
@@ -1,12 +1,18 @@
 import Foundation
 import SwiftData
 
-/// A Pack's suggested Sources, offered to the reader when it installs.
+/// A Pack's suggested Sources, offered to the reader rather than subscribed on
+/// their behalf.
 ///
 /// `PackInstaller` deliberately subscribes to nothing: a Source is chosen, and
 /// the suggestions are kept on the record for the app to offer. This is the
-/// other half of that sentence — what is worth offering, and what happens once
-/// the reader says yes.
+/// other half of that sentence — what is worth offering, what happens once the
+/// reader says yes, and what happens once they say no.
+///
+/// There is exactly one exception, and it is not here: the very first launch of
+/// an empty store subscribes the Active Pack's suggestions outright, because a
+/// reader with nothing to read cannot be offered anything worth reading. See
+/// `SeedData.acquireSourcesIfNeeded` and ADR-0011.
 @MainActor
 enum PackSourceOffer {
 
@@ -22,8 +28,16 @@ enum PackSourceOffer {
     /// Source every time a suggestion needed escaping — and offer it forever.
     static func pending(_ suggestions: [PackFile.PackSource],
                         context: ModelContext) -> [PackFile.PackSource] {
-        let subscribed = Set(((try? context.fetch(FetchDescriptor<FeedSource>())) ?? [])
-            .map(\.url.absoluteString))
+        pending(suggestions, subscribedTo: subscribedURLs(context: context))
+    }
+
+    /// The same question asked of Sources the caller already has in hand.
+    ///
+    /// `SettingsView` holds them in a `@Query` and redraws its body on every
+    /// toggle, so re-fetching them per redraw would pay for a list it was
+    /// already handed.
+    static func pending(_ suggestions: [PackFile.PackSource],
+                        subscribedTo subscribed: Set<String>) -> [PackFile.PackSource] {
         var offered: Set<String> = []
         return suggestions.filter { suggestion in
             guard let stored = url(suggestion)?.absoluteString,
@@ -55,6 +69,70 @@ enum PackSourceOffer {
             return 0
         }
         return new.count
+    }
+
+    // MARK: - The standing offer
+
+    /// The Active Pack's suggestions the app raises unprompted: the ones the
+    /// reader has neither subscribed to nor turned down.
+    ///
+    /// This is what a Source added to a Pack in a new version of the app
+    /// arrives as. Subscribing it at launch instead would be the app choosing a
+    /// Source on the reader's behalf — and, because `pending` filters out what
+    /// is already subscribed, would suppress the offer for that Source
+    /// permanently: the reader could never be asked, because they already had
+    /// it (#47).
+    static func standing(_ suggestions: [PackFile.PackSource],
+                         subscribedTo subscribed: Set<String>) -> [PackFile.PackSource] {
+        let refused = declined
+        return pending(suggestions, subscribedTo: subscribed).filter { suggestion in
+            url(suggestion).map { !refused.contains($0.absoluteString) } ?? false
+        }
+    }
+
+
+    private nonisolated static let declinedKey = "declinedSourceSuggestions"
+
+    /// What a store wipe has to clear to leave a fresh install. A decline is
+    /// deliberately kept outside the store, so emptying the store cannot reach
+    /// it — the same reason `ActivePackIdentity` needs forgetting explicitly.
+    nonisolated static let defaultsKeys = [declinedKey]
+
+    /// Suggestions the reader has been shown and left unchecked.
+    ///
+    /// Kept in `UserDefaults` rather than the store, alongside the other
+    /// memories that outlive a record (`ActivePackIdentity`): a decline is
+    /// about what the reader has been asked, not about what their map holds,
+    /// and it has to survive a Pack being reinstalled over the top.
+    ///
+    /// Stored as the URL `FeedSource` would store, so it compares against the
+    /// same string `pending` does.
+    static var declined: Set<String> {
+        Set(UserDefaults.standard.stringArray(forKey: declinedKey) ?? [])
+    }
+
+    /// Records suggestions the reader was shown and did not take, so the
+    /// standing offer stops raising them.
+    ///
+    /// Only `standing` consults this. Installing a Pack by hand is a reader
+    /// asking to see its Sources, so `PackLibraryView` offers all of them
+    /// again — which is also the only way back from a decline.
+    static func recordDeclined(_ suggestions: [PackFile.PackSource]) {
+        let urls = suggestions.compactMap { url($0)?.absoluteString }
+        guard !urls.isEmpty else { return }
+        UserDefaults.standard.set(declined.union(urls).sorted(), forKey: declinedKey)
+    }
+
+    /// Drops the record. For tests, which share one `UserDefaults` across stores.
+    static func forgetDeclined() {
+        UserDefaults.standard.removeObject(forKey: declinedKey)
+    }
+
+    // MARK: - Reading the store
+
+    private static func subscribedURLs(context: ModelContext) -> Set<String> {
+        Set(((try? context.fetch(FetchDescriptor<FeedSource>())) ?? [])
+            .map(\.url.absoluteString))
     }
 
     /// A suggestion the sync could never fetch is not a place reading can arrive

--- a/TechPulse/Services/PackSourceOffer.swift
+++ b/TechPulse/Services/PackSourceOffer.swift
@@ -71,6 +71,65 @@ enum PackSourceOffer {
         return new.count
     }
 
+    // MARK: - What the sheet opens with, and what Add means
+
+    /// The longest offer that opens with every suggestion ticked.
+    ///
+    /// Pre-checking is consent by default, and it is honest only while the
+    /// reader can see what they are agreeing to. The built-in Packs suggest 14
+    /// and 13 — the largest list the app itself vouches for — and a list that
+    /// size reads in one screen, where having nothing to read is a worse first
+    /// impression than one Source too many. A Pack past this is asking for more
+    /// than the app ever asks for, and a list that long is one nobody scrolled
+    /// before tapping Add.
+    ///
+    /// Well under `PackFile.maxSuggestedSources`, deliberately. The cap says
+    /// what a Pack may suggest; this says what the app will take on the reader's
+    /// behalf, and the second is the smaller question (#20).
+    static let preCheckedUpTo = 15
+
+    /// Whether an offer this long arrives ticked. The rule `accept` needs as
+    /// well as the sheet, which is why it is a question and not a private
+    /// comparison inside `preChecked`.
+    static func opensTicked(_ sources: [PackFile.PackSource]) -> Bool {
+        sources.count <= preCheckedUpTo
+    }
+
+    /// What opens ticked: all of them, or none.
+    ///
+    /// All-or-nothing rather than the first fifteen. Which suggestions a Pack
+    /// listed first is the author's ordering, not a ranking the app can read as
+    /// consent, and a half-ticked list invites the reader to trust the ticks
+    /// instead of the names.
+    static func preChecked(_ sources: [PackFile.PackSource]) -> Set<String> {
+        opensTicked(sources) ? Set(sources.map(\.url)) : []
+    }
+
+    /// Answering the offer: subscribe what the reader ticked, and record what
+    /// they turned down.
+    ///
+    /// **An unticked box is an answer only where the box arrived ticked.**
+    /// ADR-0011 made a leftover count as a decline because the sheet was always
+    /// pre-ticked, so unticking was deliberate. Above `preCheckedUpTo` nothing
+    /// arrives ticked, and a reader who ticks three of thirty-one has said
+    /// nothing whatever about the other twenty-eight — recording those as
+    /// declined would bury them close to permanently, on a list the reader was
+    /// never shown as ticked. Unanswered is what the standing offer is for, and
+    /// "Not now" is still there for a reader who means to refuse the lot.
+    ///
+    /// One call rather than two at the call site, so the rule cannot be
+    /// half-applied by a caller that remembers to subscribe and forgets what
+    /// silence meant.
+    @discardableResult
+    static func accept(_ accepted: Set<String>,
+                       of offered: [PackFile.PackSource],
+                       context: ModelContext) -> Int {
+        if opensTicked(offered) {
+            recordDeclined(offered.filter { !accepted.contains($0.url) })
+        }
+        return subscribe(offered.filter { accepted.contains($0.url) }, context: context)
+    }
+
     // MARK: - The standing offer
 
     /// The Active Pack's suggestions the app raises unprompted: the ones the

--- a/TechPulse/Services/SeedData.swift
+++ b/TechPulse/Services/SeedData.swift
@@ -1,64 +1,76 @@
 import SwiftData
 import Foundation
 
-/// Default AI feed sources (user-editable in Settings), per build spec §8.
+/// What a store holds before the reader has done anything: the Sources their
+/// Pack suggests, and the knowledge their resume already proves.
 enum SeedData {
-    static let defaultSources: [(name: String, url: String, category: String)] = [
-        ("arXiv cs.AI", "https://export.arxiv.org/rss/cs.AI", "Research"),
-        ("arXiv cs.LG", "https://export.arxiv.org/rss/cs.LG", "Research"),
-        ("arXiv cs.CL", "https://export.arxiv.org/rss/cs.CL", "Research"),
-        ("Apple ML Research", "https://machinelearning.apple.com/rss.xml", "Research"),
-        ("Hugging Face Blog", "https://huggingface.co/blog/feed.xml", "Open Source"),
-        // Vote-ranked, which is the whole point of it: what a Source is ordered
-        // by is part of what you subscribed to, so community attention reaches
-        // the 🔥 lane without the app ever learning that popularity exists
-        // (ADR-0003, #46). One such Source, not several — they share a host,
-        // so they would share a queue (#44).
-        ("r/MachineLearning (top this week)", "https://www.reddit.com/r/MachineLearning/top/.rss?t=week", "LLMs"),
-        ("OpenAI News", "https://openai.com/news/rss.xml", "Frontier Labs"),
-        ("Google DeepMind Blog", "https://deepmind.google/blog/rss.xml", "Frontier Labs"),
-        ("MIT Technology Review — AI", "https://www.technologyreview.com/topic/artificial-intelligence/feed", "Industry"),
-        ("The Verge — AI", "https://www.theverge.com/rss/ai-artificial-intelligence/index.xml", "Industry"),
-        ("VentureBeat — AI", "https://venturebeat.com/category/ai/feed/", "Industry"),
-        ("TechCrunch — AI", "https://techcrunch.com/category/artificial-intelligence/feed/", "Industry"),
-        ("Kaggle (r/kaggle)", "https://www.reddit.com/r/kaggle/.rss", "Data Science"),
-        ("KDnuggets", "https://www.kdnuggets.com/feed", "Data Science"),
-    ]
-
-    /// Once-shipped defaults that turned out dead; removed from installs that
-    /// received them. (Kaggle's Medium blog stopped posting in 2020.)
     private static let retiredSourceURLs: Set<String> = [
         "https://medium.com/feed/kaggle-blog",
     ]
 
     @MainActor
     static func seedIfNeeded(context: ModelContext) {
-        // Incremental: insert any default source not already present, so app
-        // updates deliver new feeds to existing installs. Safe because
-        // Settings can only toggle sources, not delete them — re-inserting
-        // can't resurrect something the user removed.
-        let existingSources = (try? context.fetch(FetchDescriptor<FeedSource>())) ?? []
-        var changed = false
-        for source in existingSources where retiredSourceURLs.contains(source.url.absoluteString) {
-            context.delete(source)
-            changed = true
-        }
-        let knownURLs = Set(existingSources.map(\.url.absoluteString))
-        for source in defaultSources where !knownURLs.contains(source.url) {
-            guard let url = URL(string: source.url) else { continue }
-            context.insert(FeedSource(name: source.name, url: url, category: source.category))
-            changed = true
-        }
-        if changed { try? context.save() }
         seedResumeKnowledgeIfNeeded(context: context)
         // After the resume: the built-in Pack installs over the top, so
         // anything already known (Fine-Tuning, PyTorch) stays green and
         // everything joins its Cluster. The map now comes from a Pack file.
         PackMigration.ensureBuiltinInstalled(context: context)
+        // After the Pack, not before it: which Sources this reader should be
+        // offered comes from the Pack they are on, and which Pack that is is
+        // only settled by the line above (#47).
+        acquireSourcesIfNeeded(context: context)
         // Both kinds of derived edge are settled at launch, so a store written
         // before either existed opens on the same map a fresh install would.
         PackMigration.ensureSemanticLinks(context: context)
         KnowledgeEngine.rebuildCoreadLinks(context: context)
+    }
+
+    /// What the app may do to a reader's Sources unprompted, which is almost
+    /// nothing: retire the ones that turned out dead, and — on a store that
+    /// had none at all — subscribe what the Active Pack suggests.
+    @MainActor
+    static func acquireSourcesIfNeeded(context: ModelContext) {
+        let existing = (try? context.fetch(FetchDescriptor<FeedSource>())) ?? []
+        retireDeadSources(among: existing, context: context)
+        // Measured before the retirement, deliberately. A store that held
+        // Sources has had its first launch, whatever retiring one leaves
+        // behind — re-seeding it would hand back Sources the reader was never
+        // offered, which is the thing this whole path exists to stop.
+        guard existing.isEmpty else { return }
+        subscribeToTheActivePacksSuggestions(context: context)
+    }
+
+    /// Removes Sources that were once shipped and have since gone quiet.
+    /// (Kaggle's Medium blog stopped posting in 2020.)
+    @MainActor
+    private static func retireDeadSources(among existing: [FeedSource],
+                                          context: ModelContext) {
+        let dead = existing.filter { retiredSourceURLs.contains($0.url.absoluteString) }
+        guard !dead.isEmpty else { return }
+        dead.forEach(context.delete)
+        try? context.save()
+    }
+
+    /// The one moment the app subscribes on the reader's behalf: a store with
+    /// nothing to read at all.
+    ///
+    /// An offer needs a Feed to be weighed against, and an empty app is a worse
+    /// first impression than a Source too many — the reader can turn any of them
+    /// off in Settings, which is where an offer would have sent them.
+    ///
+    /// Every launch after this subscribes to nothing. A Source added to a Pack
+    /// in a new version of the app is *offered* instead, and waits in Settings
+    /// until the reader answers. Subscribing it here would deliver a Source
+    /// nobody chose and then suppress the offer for it permanently, because
+    /// `PackSourceOffer.pending` filters out what is already subscribed — the
+    /// reader could never be asked, because they already had it (#47, ADR-0011).
+    ///
+    /// Reading the Active Pack rather than a compiled list is the other half: a
+    /// reader on Security Engineering is asked about Security Engineering's
+    /// Sources, and stops being handed the flagship's.
+    @MainActor
+    private static func subscribeToTheActivePacksSuggestions(context: ModelContext) {
+        PackSourceOffer.subscribe(ActivePack.inUse.suggestedSources, context: context)
     }
 
     /// The resume's projects as co-read groups: Concepts used on the same

--- a/TechPulse/Services/UITestSupport.swift
+++ b/TechPulse/Services/UITestSupport.swift
@@ -58,7 +58,7 @@ enum UITestSupport {
     /// onboarding in whatever state the last run left them.
     private static let seedingDefaultsKeys = [
         "hasOnboarded", "resumeKnowledgeSeeded", "builtinPackVersion", "knowledgePackVersion",
-    ] + ReminderScheduler.defaultsKeys
+    ] + ReminderScheduler.defaultsKeys + PackSourceOffer.defaultsKeys
 
     static var isResetRequested: Bool {
         ProcessInfo.processInfo.arguments.contains(resetStoreArgument)

--- a/TechPulse/Views/PackLibraryView.swift
+++ b/TechPulse/Views/PackLibraryView.swift
@@ -277,11 +277,23 @@ struct PackSourceOfferView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Not now") { dismiss() }
-                        .accessibilityIdentifier("declineSources")
+                    Button("Not now") {
+                        // Answered, not postponed: Settings would otherwise
+                        // raise the same suggestions at every launch. Choosing
+                        // this Pack from the library asks again — see
+                        // `PackSourceOffer.recordDeclined`.
+                        PackSourceOffer.recordDeclined(offer.sources)
+                        dismiss()
+                    }
+                    .accessibilityIdentifier("declineSources")
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add \(accepted.count)") {
+                        // The ones left unchecked were put to the reader and
+                        // turned down as surely as "Not now" turns down all of
+                        // them, so the standing offer stops raising those too.
+                        PackSourceOffer.recordDeclined(
+                            offer.sources.filter { !accepted.contains($0.url) })
                         let added = PackSourceOffer.subscribe(
                             offer.sources.filter { accepted.contains($0.url) },
                             context: modelContext)

--- a/TechPulse/Views/PackLibraryView.swift
+++ b/TechPulse/Views/PackLibraryView.swift
@@ -226,34 +226,11 @@ struct PackSourceOfferView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var accepted: Set<String>
 
-    /// The longest offer that opens with everything ticked.
-    ///
-    /// Pre-checking is consent by default, and it is honest only while the
-    /// reader can see what they are agreeing to. The built-in Packs suggest 14
-    /// and 13 — the largest list the app itself vouches for — and a list that
-    /// size reads in one screen, where having nothing to read is a worse first
-    /// impression than one Source too many. A Pack past this is asking for more
-    /// than the app ever asks for, and a list that long is one nobody scrolled
-    /// before tapping Add — so the reader ticks what they want instead.
-    ///
-    /// Well under `PackFile.maxSuggestedSources`, deliberately. The cap says
-    /// what a Pack may suggest; this says what the app will take on the reader's
-    /// behalf, and the second is the smaller question.
-    static let preCheckedUpTo = 15
-
-    /// What opens ticked: all of them, or none.
-    ///
-    /// All-or-nothing rather than the first fifteen. Which suggestions a Pack
-    /// listed first is the author's ordering, not a ranking the app can read as
-    /// consent, and a half-ticked list invites the reader to trust the ticks
-    /// instead of the names.
-    static func preChecked(_ sources: [PackFile.PackSource]) -> Set<String> {
-        sources.count <= preCheckedUpTo ? Set(sources.map(\.url)) : []
-    }
-
     init(offer: SourceOffer) {
         self.offer = offer
-        _accepted = State(initialValue: Self.preChecked(offer.sources))
+        // Ticked or not by the same rule `PackSourceOffer.accept` reads when it
+        // decides whether silence was an answer — one policy, not two.
+        _accepted = State(initialValue: PackSourceOffer.preChecked(offer.sources))
     }
 
     var body: some View {
@@ -311,14 +288,11 @@ struct PackSourceOfferView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add \(accepted.count)") {
-                        // The ones left unchecked were put to the reader and
-                        // turned down as surely as "Not now" turns down all of
-                        // them, so the standing offer stops raising those too.
-                        PackSourceOffer.recordDeclined(
-                            offer.sources.filter { !accepted.contains($0.url) })
-                        let added = PackSourceOffer.subscribe(
-                            offer.sources.filter { accepted.contains($0.url) },
-                            context: modelContext)
+                        // Subscribing and recording what was turned down are one
+                        // call, because what an unticked box means depends on
+                        // whether it arrived ticked — see `PackSourceOffer.accept`.
+                        let added = PackSourceOffer.accept(accepted, of: offer.sources,
+                                                           context: modelContext)
                         dismiss()
                         // Sources are only synced by themselves when the Feed
                         // is half an hour stale, and the point of taking these

--- a/TechPulse/Views/PackLibraryView.swift
+++ b/TechPulse/Views/PackLibraryView.swift
@@ -226,12 +226,34 @@ struct PackSourceOfferView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var accepted: Set<String>
 
+    /// The longest offer that opens with everything ticked.
+    ///
+    /// Pre-checking is consent by default, and it is honest only while the
+    /// reader can see what they are agreeing to. The built-in Packs suggest 14
+    /// and 13 — the largest list the app itself vouches for — and a list that
+    /// size reads in one screen, where having nothing to read is a worse first
+    /// impression than one Source too many. A Pack past this is asking for more
+    /// than the app ever asks for, and a list that long is one nobody scrolled
+    /// before tapping Add — so the reader ticks what they want instead.
+    ///
+    /// Well under `PackFile.maxSuggestedSources`, deliberately. The cap says
+    /// what a Pack may suggest; this says what the app will take on the reader's
+    /// behalf, and the second is the smaller question.
+    static let preCheckedUpTo = 15
+
+    /// What opens ticked: all of them, or none.
+    ///
+    /// All-or-nothing rather than the first fifteen. Which suggestions a Pack
+    /// listed first is the author's ordering, not a ranking the app can read as
+    /// consent, and a half-ticked list invites the reader to trust the ticks
+    /// instead of the names.
+    static func preChecked(_ sources: [PackFile.PackSource]) -> Set<String> {
+        sources.count <= preCheckedUpTo ? Set(sources.map(\.url)) : []
+    }
+
     init(offer: SourceOffer) {
         self.offer = offer
-        // Pre-checked: these are the author's suggestions for the map the
-        // reader just chose, and having nothing to read is a worse first
-        // impression than one Source too many.
-        _accepted = State(initialValue: Set(offer.sources.map(\.url)))
+        _accepted = State(initialValue: Self.preChecked(offer.sources))
     }
 
     var body: some View {

--- a/TechPulse/Views/SettingsView.swift
+++ b/TechPulse/Views/SettingsView.swift
@@ -12,6 +12,9 @@ struct SettingsView: View {
     @State private var hasKey = KeychainStore.hasAnthropicKey
     @State private var intention = ReminderScheduler.intention
     @State private var notificationsRefused = false
+    /// Set when the reader opens the standing offer. A Source is chosen, so
+    /// this screen shows what is suggested and subscribes to none of it.
+    @State private var offer: SourceOffer?
 
     private var lastSynced: Date? {
         sources.compactMap(\.lastFetched).max()
@@ -20,6 +23,18 @@ struct SettingsView: View {
     /// The Pack the map is of, named here so the reader can see it without
     /// opening the chooser.
     private var activePack: InstalledPack? { activePacks.first }
+
+    /// The Active Pack's suggestions the reader has neither taken nor turned
+    /// down. This is where a Source added to a Pack in a new version of the app
+    /// arrives — launch subscribes to nothing after the first one, so without a
+    /// row here it would reach nobody (#47).
+    ///
+    /// Read off the `@Query` above rather than fetched: this body redraws on
+    /// every toggle in the list below it.
+    private var suggested: [PackFile.PackSource] {
+        PackSourceOffer.standing(ActivePack.inUse.suggestedSources,
+                                 subscribedTo: Set(sources.map(\.url.absoluteString)))
+    }
 
     /// SwiftData store size on disk (design 2f "Storage used").
     private var storageUsed: String {
@@ -54,6 +69,28 @@ struct SettingsView: View {
                     SettingsHeader("Map")
                 } footer: {
                     Text("The Pack is the field your map covers. Switch to another built-in Pack, or import one you were given — what you have learned comes with you.")
+                }
+                if !suggested.isEmpty {
+                    Section {
+                        Button {
+                            offer = SourceOffer(field: activePack?.field ?? ActivePack.inUse.field,
+                                                sources: suggested)
+                        } label: {
+                            LabeledContent {
+                                Text("\(suggested.count)")
+                            } label: {
+                                Text(suggested.count == 1
+                                     ? "1 new Source suggested"
+                                     : "\(suggested.count) new Sources suggested")
+                                    .foregroundStyle(Theme.stateLearning)
+                            }
+                        }
+                        .accessibilityIdentifier("suggestedSourcesRow")
+                    } header: {
+                        SettingsHeader("Suggested")
+                    } footer: {
+                        Text("Your Pack suggests these and you are not subscribed to them. Nothing is subscribed until you say so.")
+                    }
                 }
                 ForEach(grouped, id: \.category) { group in
                     Section {
@@ -195,6 +232,9 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .scrollContentBackground(.hidden)
             .background(Theme.background)
+            .sheet(item: $offer) { offer in
+                PackSourceOfferView(offer: offer)
+            }
         }
     }
 }

--- a/Tests/UITests/Journey.swift
+++ b/Tests/UITests/Journey.swift
@@ -1,5 +1,25 @@
 import XCTest
 
+/// One reading of a control: everything a journey's conditions ask about it,
+/// taken in a single query.
+///
+/// The point is what is *not* here. There is no `exists` field, because
+/// existence is the optional: a control that has gone has no snapshot to
+/// report, so `nil` is "not there" — the same meaning `!exists` carried, in the
+/// one place a condition can still see it. And there is no element, so a
+/// condition holding one of these cannot go back and ask a second question of
+/// an app that has moved on since the first (#53).
+///
+/// Three attributes because three are what the journeys wait on. `isHittable`
+/// is deliberately absent: XCUITest does not carry it on a snapshot, so it
+/// cannot be read in the same query as the rest and would be a second round
+/// trip wearing this type's clothes.
+struct ElementState: Equatable {
+    let label: String
+    let isEnabled: Bool
+    let isSelected: Bool
+}
+
 /// Drives one UI journey and keeps its books (#30).
 ///
 /// Two rules, both paid for by #26. **Every step is declared up front** and has
@@ -89,15 +109,8 @@ final class Journey {
         return element
     }
 
-    /// Waits for an element to go away — a sheet dismissing, a picker closing.
-    /// Polled rather than `waitForNonExistence`, whose granularity is a second
-    /// and which therefore charges one for every dismissal in the suite.
-    func waitUntilGone(_ element: XCUIElement, _ what: String, timeout: TimeInterval = 10,
-                       file: StaticString = #filePath, line: UInt = #line) {
-        waitUntil(what, timeout: timeout, file: file, line: line) { !element.exists }
-    }
-
-    /// What a control says, or nil if it is not there — read in **one** query.
+    /// What a control is right now, or nil if it is not there — read in **one**
+    /// query.
     ///
     /// `exists` and `label` are two separate queries against a live app, and a
     /// control that goes between them makes the second one throw rather than
@@ -109,34 +122,77 @@ final class Journey {
     /// happen — and `testCoreJourney` failed about one run in two on it (#48).
     ///
     /// One snapshot, so "not there" is a value the caller can branch on.
-    /// `static` because reading a label needs nothing a journey holds; it is
+    /// `static` because reading a control needs nothing a journey holds; it is
     /// here so it sits with the other ways this file reads a live app.
     ///
     /// Nil still means gone, exactly as `!exists` did — this narrows *when* the
     /// question is asked, not what the answer means.
-    static func label(of element: XCUIElement) -> String? {
-        (try? element.snapshot())?.label
+    ///
+    /// One thing nil is *not*: proof of absence. `try?` cannot tell "there is no
+    /// such control" from "the app did not answer", so nil is "no reading to be
+    /// had". That is the right answer for a condition still waiting — silence
+    /// keeps it waiting — and the wrong one for an assertion that **passes**
+    /// when something is gone, which would pass on silence. Those ask
+    /// `waitForPresence` instead.
+    static func state(of element: XCUIElement) -> ElementState? {
+        guard let snapshot = try? element.snapshot() else { return nil }
+        return ElementState(label: snapshot.label,
+                            isEnabled: snapshot.isEnabled,
+                            isSelected: snapshot.isSelected)
     }
 
-    /// Waits for anything else worth waiting for. `what` is the condition in
-    /// words, and it is what the failure says.
+    /// Waits for something to become true **of one control**, which the
+    /// condition is handed a reading of rather than left to interrogate.
+    /// `what` is the condition in words, and it is what the failure says.
+    ///
+    /// The element is a parameter, not something the closure closes over,
+    /// because that is the whole seam (#53). A condition given the control
+    /// itself has to ask it twice — `element.exists && !element.isEnabled` is
+    /// two round trips to a moving app — and every author has to independently
+    /// know that. A condition given `ElementState?` cannot: the reading it gets
+    /// is one query old and internally consistent, and a control that has gone
+    /// arrives as nil rather than as a thrown query. There is deliberately no
+    /// wait here taking a bare `() -> Bool`, so there is nowhere left to write
+    /// the two-query form.
     ///
     /// Polls rather than using `XCTNSPredicateExpectation`: the predicate block
-    /// is `@Sendable`, and every condition here closes over an `XCUIElement`,
-    /// which is not.
+    /// is `@Sendable`, and `XCUIElement` is not.
     @discardableResult
-    func waitUntil(_ what: String, timeout: TimeInterval = 10,
+    func waitUntil(_ element: XCUIElement, _ what: String, timeout: TimeInterval = 10,
                    file: StaticString = #filePath, line: UInt = #line,
-                   _ condition: () -> Bool) -> Bool {
-        let met = poll(condition, until: timeout)
+                   _ condition: (ElementState?) -> Bool) -> Bool {
+        let met = poll({ condition(Self.state(of: element)) }, until: timeout)
         XCTAssertTrue(met, "\(title): \(what) (waited \(Int(timeout))s)", file: file, line: line)
         return met
     }
 
-    /// The same wait, but never becoming true is an answer rather than a
-    /// failure — for the steps a journey has declared it may legitimately skip.
-    func becomesTrue(_ condition: () -> Bool, within timeout: TimeInterval = 2) -> Bool {
-        poll(condition, until: timeout)
+    /// Waits for an element to go away — a sheet dismissing, a picker closing.
+    /// Polled rather than `waitForNonExistence`, whose granularity is a second
+    /// and which therefore charges one for every dismissal in the suite.
+    func waitUntilGone(_ element: XCUIElement, _ what: String, timeout: TimeInterval = 10,
+                       file: StaticString = #filePath, line: UInt = #line) {
+        let gone = waitForPresence(element, false, until: timeout)
+        XCTAssertTrue(gone, "\(title): \(what) (waited \(Int(timeout))s)", file: file, line: line)
+    }
+
+    /// Whether a control turns up within a short window — an answer rather than
+    /// a failure, for the branches a journey has declared it may legitimately
+    /// not take.
+    func appears(_ element: XCUIElement, within timeout: TimeInterval = 2) -> Bool {
+        waitForPresence(element, true, until: timeout)
+    }
+
+    /// Waits on a control's mere presence, and says whether it got there.
+    ///
+    /// Presence is asked of the element, not read off a snapshot, and that is
+    /// deliberate: `exists` answers false where a snapshot merely fails, so it
+    /// tells absence from silence. `waitUntilGone` **passes** when a control is
+    /// gone, and an assertion that passes on silence is the exact shape this
+    /// file exists to keep out (#30). There is no attribute here and so nothing
+    /// to race: presence is one query and answers itself.
+    private func waitForPresence(_ element: XCUIElement, _ present: Bool,
+                                 until timeout: TimeInterval) -> Bool {
+        poll({ element.exists == present }, until: timeout)
     }
 
     private func poll(_ condition: () -> Bool, until timeout: TimeInterval,
@@ -157,10 +213,14 @@ final class Journey {
     /// it into view, which is something `tap()` itself does.
     func tap(_ element: XCUIElement, _ what: String, timeout: TimeInterval = 10,
              file: StaticString = #filePath, line: UInt = #line) {
-        let there = waitUntil("\(what) never appeared to tap", timeout: timeout,
-                              file: file, line: line) { element.exists }
+        let there = waitForPresence(element, true, until: timeout)
+        XCTAssertTrue(there, "\(title): \(what) never appeared to tap (waited \(Int(timeout))s)",
+                      file: file, line: line)
         guard there else { return }
-        _ = becomesTrue({ element.exists && element.isHittable })
+        // Hittability is the one attribute a snapshot does not carry, so it
+        // cannot go through a wait that reads one — and polling for it in here
+        // is what keeps a raw `() -> Bool` wait off a journey's menu.
+        _ = poll({ element.exists && element.isHittable }, until: 2)
         // Between the wait and the tap the screen can move on — a sheet that
         // re-renders takes its buttons with it — and tapping something that has
         // gone raises rather than failing. Say which control went instead.

--- a/Tests/UITests/JourneyReadTests.swift
+++ b/Tests/UITests/JourneyReadTests.swift
@@ -2,41 +2,95 @@ import XCTest
 
 /// How the journeys read a live app.
 ///
-/// `Journey.label(of:)` exists because `exists` then `label` is two queries,
-/// and a control that goes between them makes the second one throw rather than
-/// answer — a thrown query, which reads as a broken journey rather than a
-/// failing one. `testCoreJourney` lost that race about one run in two (#48).
+/// `exists` then `label` is two queries, and a control that goes between them
+/// makes the second one throw rather than answer — a thrown query, which reads
+/// as a broken journey rather than a failing one. `testCoreJourney` lost that
+/// race about one run in two (#48).
+///
+/// #48 closed the three sites that were losing it. #53 moved the seam: a
+/// condition is now *handed* one reading of a control, so there is no second
+/// query for the next wait anyone writes to lose. These tests hold both halves
+/// of that — the read, and the wait built on it.
 @MainActor
 final class JourneyReadTests: XCTestCase {
+
+    /// A wiped launch with no `Journey` around it. The two tests below are
+    /// about the read itself, which is `static` precisely because it needs
+    /// nothing a journey holds — the two after them are about the wait, and
+    /// build a journey because that is what they are testing.
+    private func launchedOnAWipedStore() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments += [UITestLaunch.resetStore]
+        app.launch()
+        return app
+    }
 
     /// The half that used to throw. Measured against a query that matches
     /// nothing, which is the state a vanished control leaves behind: this is
     /// the read the journey performs, at the moment it performs it.
-    func testLabelOfSomethingNotThereIsNilRatherThanAThrownQuery() {
-        let app = XCUIApplication()
-        app.launchArguments += [UITestLaunch.resetStore]
-        app.launch()
+    func testStateOfSomethingNotThereIsNilRatherThanAThrownQuery() {
+        let app = launchedOnAWipedStore()
 
         let gone = app.buttons["noSuchControlInThisApp"].firstMatch
         XCTAssertFalse(gone.exists, "the fixture must name a control the app does not have")
         // Reading `gone.label` here is what fails the suite with
         // “Failed to get matching snapshot: No matches found…”.
-        XCTAssertNil(Journey.label(of: gone))
+        XCTAssertNil(Journey.state(of: gone))
     }
 
-    /// And the other half, so the helper cannot pass the test above by being
-    /// nil for everything — which would make every wait built on it return
-    /// true immediately and every journey silently green.
-    func testLabelOfSomethingPresentIsWhatItSays() {
-        let app = XCUIApplication()
-        app.launchArguments += [UITestLaunch.resetStore]
-        app.launch()
+    /// And the other half, so the read cannot pass the test above by being nil
+    /// for everything — which would make every wait built on it return true
+    /// immediately and every journey silently green.
+    ///
+    /// Both attributes come out of the one snapshot, which is the property
+    /// worth having: a caller asking what a control says *and* whether it is
+    /// still on gets one app, not two.
+    func testStateOfSomethingPresentIsWhatItSaysAndWhetherItIsOn() {
+        let app = launchedOnAWipedStore()
 
         let onboarding = app.buttons["onboardingContinue"].firstMatch
         XCTAssertTrue(onboarding.waitForExistence(timeout: 30),
                       "a wiped store opens on onboarding")
-        let says = Journey.label(of: onboarding)
-        XCTAssertNotNil(says)
-        XCTAssertFalse(says?.isEmpty ?? true, "a button that is there says something")
+        let state = Journey.state(of: onboarding)
+        XCTAssertNotNil(state)
+        XCTAssertFalse(state?.label.isEmpty ?? true, "a button that is there says something")
+        XCTAssertEqual(state?.isEnabled, true, "Continue is offered with topics preselected")
+    }
+
+    /// The seam itself: a wait is handed the state, and a control that has gone
+    /// arrives as `nil` rather than as a thrown query. Nil still means gone,
+    /// exactly as `!exists` did.
+    func testAWaitIsHandedNilForAControlThatHasGone() {
+        let journey = Journey("journey reads", steps: [])
+        journey.start()
+
+        let gone = journey.app.buttons["noSuchControlInThisApp"].firstMatch
+        var seen: [ElementState?] = []
+        journey.waitUntil(gone, "the condition was never handed anything") { state in
+            seen.append(state)
+            return true
+        }
+
+        XCTAssertEqual(seen.count, 1, "the condition should be asked once and answered")
+        XCTAssertNil(seen.first ?? nil, "a control that is not there is nil, not a thrown query")
+        journey.finish()
+    }
+
+    /// And a wait on a control that is there is handed its attributes, so a
+    /// condition can branch on what it says without going back to the app.
+    func testAWaitIsHandedTheAttributesOfAControlThatIsThere() {
+        let journey = Journey("journey reads", steps: [])
+        journey.start()
+
+        let onboarding = journey.app.buttons["onboardingContinue"].firstMatch
+        var seen: ElementState?
+        journey.waitUntil(onboarding, "onboarding never appeared on a wiped store", timeout: 30) { state in
+            seen = state
+            return state != nil
+        }
+
+        XCTAssertEqual(seen?.isEnabled, true)
+        XCTAssertFalse(seen?.label.isEmpty ?? true)
+        journey.finish()
     }
 }

--- a/Tests/UITests/TechPulseUITests.swift
+++ b/Tests/UITests/TechPulseUITests.swift
@@ -55,7 +55,8 @@ final class TechPulseUITests: XCTestCase {
         let continueButton = app.buttons["onboardingContinue"].firstMatch
         journey.waitFor(continueButton, "onboarding never appeared on a wiped store", timeout: 20)
         journey.snap("0-onboarding")
-        XCTAssertTrue(continueButton.isEnabled, "Continue disabled despite preselected topics")
+        XCTAssertEqual(Journey.state(of: continueButton)?.isEnabled, true,
+                       "Continue disabled despite preselected topics")
         continueButton.tap()
         journey.waitUntilGone(continueButton, "the topics step never gave way")
 
@@ -80,10 +81,9 @@ final class TechPulseUITests: XCTestCase {
         // finished — the header says which, so wait for what it says.
         let firstCard = app.buttons["articleCard"].firstMatch
         journey.waitFor(firstCard, "feed never loaded articles", timeout: 90)
-        journey.waitUntil("the feed never finished syncing", timeout: 120) {
-            !app.staticTexts.matching(NSPredicate(format: "label BEGINSWITH 'Syncing'"))
-                .firstMatch.exists
-        }
+        let syncing = app.staticTexts
+            .matching(NSPredicate(format: "label BEGINSWITH 'Syncing'")).firstMatch
+        journey.waitUntilGone(syncing, "the feed never finished syncing", timeout: 120)
         journey.settle("the feed to stop filling in")
         journey.snap("1-feed")
 
@@ -126,9 +126,12 @@ final class TechPulseUITests: XCTestCase {
         // before and refused after.
         let know = app.buttons["knowButton"].firstMatch
         journey.waitFor(know, "the sheet has no “I know this” button")
-        XCTAssertTrue(know.isEnabled, "“I know this” was already spent on a Concept the journey just met")
+        XCTAssertEqual(Journey.state(of: know)?.isEnabled, true,
+                       "“I know this” was already spent on a Concept the journey just met")
         know.tap()
-        journey.waitUntil("the Concept never became Known") { know.exists && !know.isEnabled }
+        // Nil keeps waiting: the button is meant to stay and refuse, so a
+        // sheet that took it away is a failure and not a pass.
+        journey.waitUntil(know, "the Concept never became Known") { $0?.isEnabled == false }
         journey.snap("4-marked-known")
 
         // Dismiss through the affordance built for it, not `swipeDown`.
@@ -147,8 +150,9 @@ final class TechPulseUITests: XCTestCase {
         // "no cluster cards" — which is what #26 was reported as.
         let knowledgeTab = app.buttons["Knowledge"]
         journey.tap(knowledgeTab, "Knowledge tab")
-        journey.waitUntil("Knowledge tab never became selected — a modal likely swallowed the tap") {
-            knowledgeTab.isSelected
+        journey.waitUntil(knowledgeTab,
+                          "Knowledge tab never became selected — a modal likely swallowed the tap") {
+            $0?.isSelected == true
         }
         journey.settle("the cluster overview to draw")
         journey.snap("5-cluster-overview")
@@ -175,7 +179,7 @@ final class TechPulseUITests: XCTestCase {
         journey.settle("the frontier Concept's sheet to finish opening")
         let find = app.buttons["findArticles"].firstMatch
         let row = app.buttons["conceptArticleRow"].firstMatch
-        let searchOffered = journey.becomesTrue({ find.exists })
+        let searchOffered = journey.appears(find)
         XCTAssertTrue(searchOffered || row.exists,
                       "the frontier Concept offers neither an Article to read nor a search to find one")
         var foundNothing = false
@@ -186,14 +190,14 @@ final class TechPulseUITests: XCTestCase {
             // Concept holding three Articles is no longer offered a search.
             // Waiting for it to merely *disable* would catch the search
             // starting, and screenshot the spinner.
-            journey.waitUntil("the arXiv search never came back", timeout: 45) {
+            journey.waitUntil(find, "the arXiv search never came back", timeout: 45) { state in
                 // Gone is an answer, and so is either result it reports. A
                 // search still running keeps the button and its spinner, so
                 // this still times out loudly when nothing comes back.
-                guard let says = Journey.label(of: find) else { return true }
+                guard let says = state?.label else { return true }
                 return says.contains("Added") || says.contains("No new matches")
             }
-            foundNothing = Journey.label(of: find)?.contains("No new matches") ?? false
+            foundNothing = Journey.state(of: find)?.label.contains("No new matches") ?? false
             journey.snap("5b2b-topic-search")
         }
         if !foundNothing {
@@ -256,7 +260,7 @@ final class TechPulseUITests: XCTestCase {
 
         let progressTab = app.buttons["Progress"]
         journey.tap(progressTab, "Progress tab")
-        journey.waitUntil("Progress tab never became selected") { progressTab.isSelected }
+        journey.waitUntil(progressTab, "Progress tab never became selected") { $0?.isSelected == true }
         journey.settle("the progress charts to draw")
         journey.snap("6-progress-charts")
 
@@ -267,7 +271,7 @@ final class TechPulseUITests: XCTestCase {
         // precisely because the journey never captured it.
         let settingsTab = app.buttons["Settings"]
         journey.tap(settingsTab, "Settings tab")
-        journey.waitUntil("Settings tab never became selected") { settingsTab.isSelected }
+        journey.waitUntil(settingsTab, "Settings tab never became selected") { $0?.isSelected == true }
         journey.settle("Settings to draw")
         journey.snap("9-settings")
         app.swipeUp()
@@ -332,7 +336,7 @@ final class TechPulseUITests: XCTestCase {
         let related = app.buttons["relatedConceptChip"].firstMatch
         let sectionHeader = app.staticTexts
             .matching(NSPredicate(format: "label CONTAINS[c] 'Related concepts'")).firstMatch
-        let offered = journey.becomesTrue({ related.exists })
+        let offered = journey.appears(related)
         XCTAssertEqual(offered, sectionHeader.exists,
                        "the sheet's related-Concepts section and its chips disagree")
         XCTAssertTrue(offered, missing)
@@ -354,8 +358,8 @@ final class TechPulseUITests: XCTestCase {
         let app = journey.app
         let start = app.buttons["startQuiz"].firstMatch
         journey.waitFor(start, "the Progress tab offers no weekly quiz")
-        XCTAssertTrue(start.isEnabled,
-                      "the weekly quiz has no candidates, though every Pack Concept carries a definition")
+        XCTAssertEqual(Journey.state(of: start)?.isEnabled, true,
+                       "the weekly quiz has no candidates, though every Pack Concept carries a definition")
         journey.tap(start, "start quiz")
 
         let action = app.buttons["quizAction"].firstMatch
@@ -370,14 +374,15 @@ final class TechPulseUITests: XCTestCase {
             let option = app.buttons["quizOption"].firstMatch
             journey.waitFor(option, "question \(answered + 1) offered no options")
             option.tap()
-            journey.waitUntil("question \(answered + 1) never accepted an answer") {
-                action.exists && action.isEnabled
+            journey.waitUntil(action, "question \(answered + 1) never accepted an answer") {
+                $0?.isEnabled == true
             }
             action.tap()                                   // check answer
-            journey.waitUntil("question \(answered + 1) never showed whether the answer was right") {
+            journey.waitUntil(action,
+                              "question \(answered + 1) never showed whether the answer was right") {
                 // Gone or relabelled, read in one query — the same race
                 // the find-articles button lost (#48).
-                Journey.label(of: action) != "Check answer"
+                $0?.label != "Check answer"
             }
             journey.tap(action, "the way on from question \(answered + 1)")
             answered += 1
@@ -463,7 +468,7 @@ final class TechPulseUITests: XCTestCase {
         // got. If one does appear (a Pack gained a Source), decline it: this
         // journey is about switching back, not about changing Sources.
         let decline = app.buttons["declineSources"].firstMatch
-        if journey.becomesTrue({ decline.exists }) { decline.tap() }
+        if journey.appears(decline) { decline.tap() }
         journey.waitFor(app.staticTexts["AI Engineering"].firstMatch,
                         "switching back did not restore the flagship Pack")
         journey.snap("10f-pack-switched-back")
@@ -515,7 +520,7 @@ final class TechPulseUITests: XCTestCase {
         // Dismissed, not answered. "Not now" would record a decline and the
         // standing offer would rightly stay quiet.
         app.swipeDown(velocity: .fast)
-        if journey.becomesTrue({ accept.exists }) { app.swipeDown(velocity: .fast) }
+        if journey.appears(accept) { app.swipeDown(velocity: .fast) }
         journey.waitUntilGone(accept, "the offer sheet never dismissed")
         journey.snap("11-offer-dismissed-unanswered")
 
@@ -590,7 +595,7 @@ final class TechPulseUITests: XCTestCase {
         // And the tab bar is live again, which is what the journey needs next.
         let progress = app.buttons["Progress"]
         journey.tap(progress, "Progress tab")
-        journey.waitUntil("tab tap still swallowed after dismissal") { progress.isSelected }
+        journey.waitUntil(progress, "tab tap still swallowed after dismissal") { $0?.isSelected == true }
 
         journey.finish()
     }

--- a/Tests/UITests/TechPulseUITests.swift
+++ b/Tests/UITests/TechPulseUITests.swift
@@ -479,6 +479,70 @@ final class TechPulseUITests: XCTestCase {
         journey.finish()
     }
 
+    /// The standing offer: a suggestion the reader neither took nor turned down
+    /// waits for them in Settings.
+    ///
+    /// This is the only surface the offer has (ADR-0011). Launch subscribes to
+    /// nothing after the first one, so a Source added to a Pack in a new version
+    /// of the app reaches the reader through this row or through nothing.
+    ///
+    /// The offer is left unanswered by dismissing the sheet rather than by
+    /// tapping either button — which is what an upgrading reader's store looks
+    /// like, and the one state that puts a suggestion in neither list.
+    func testStandingSourceOfferJourney() throws {
+        let journey = Journey("standing source offer", steps: [
+            .required("11-offer-dismissed-unanswered"),
+            .required("11a-settings-suggests"),
+            .required("11b-offer-reopened"),
+            .required("11c-suggestion-taken"),
+        ], launchArguments: ["-hasOnboarded", "YES"])
+        let app = journey.app
+        journey.start()
+
+        // Switch to the other built-in Pack, which suggests Sources the wiped
+        // store's first launch did not subscribe to.
+        journey.tap(app.buttons["Settings"], "Settings tab")
+        let packRow = app.buttons["packRow"].firstMatch
+        journey.waitFor(packRow, "Settings has no Pack row")
+        journey.tap(packRow, "Pack row")
+        let builtins = app.buttons.matching(identifier: "builtinPack")
+        journey.waitFor(builtins.element(boundBy: 0), "no built-in packs listed")
+        journey.tap(builtins.element(boundBy: 1), "the second built-in Pack")
+
+        let accept = app.buttons["acceptSources"].firstMatch
+        journey.waitFor(accept, "the Pack's suggested Sources were never offered", timeout: 15)
+
+        // Dismissed, not answered. "Not now" would record a decline and the
+        // standing offer would rightly stay quiet.
+        app.swipeDown(velocity: .fast)
+        if journey.becomesTrue({ accept.exists }) { app.swipeDown(velocity: .fast) }
+        journey.waitUntilGone(accept, "the offer sheet never dismissed")
+        journey.snap("11-offer-dismissed-unanswered")
+
+        // The unanswered suggestions are waiting in Settings.
+        journey.goBack(to: packRow, "Settings never came back")
+        let suggested = app.buttons["suggestedSourcesRow"].firstMatch
+        journey.waitFor(suggested, """
+            an offer the reader never answered reached neither their Sources \
+            nor the Settings row that is supposed to hold it
+            """)
+        journey.snap("11a-settings-suggests")
+
+        // And the row opens the same offer.
+        journey.tap(suggested, "the suggested Sources row")
+        journey.waitFor(accept, "the Settings row did not open the offer", timeout: 15)
+        journey.snap("11b-offer-reopened")
+        journey.tap(accept, "accept sources")
+
+        // Taken, so the row has nothing left to hold.
+        journey.waitUntilGone(suggested, "the row outlived the suggestions it was holding")
+        journey.scroll(to: app.staticTexts["Krebs on Security"].firstMatch,
+                       "the accepted Sources never reached Settings")
+        journey.snap("11c-suggestion-taken")
+
+        journey.finish()
+    }
+
     // MARK: - Guards
 
     /// The Concept sheet must be dismissable **whatever its scroll position** —

--- a/Tests/UnitTests/BuiltinPacksTests.swift
+++ b/Tests/UnitTests/BuiltinPacksTests.swift
@@ -126,15 +126,15 @@ struct BuiltinPacksTests {
         #expect(specialty == KnowledgePack.sideQuestConcepts)
     }
 
-    @Test("the Pack carries its suggested Sources, matching the seeded defaults")
+    @Test("the Pack carries its suggested Sources, matching the compiled fixture")
     func carriesSuggestedSources() throws {
         let pack = try aiEngineer()
-        #expect(pack.suggestedSources.count == SeedData.defaultSources.count)
+        #expect(pack.suggestedSources.count == KnowledgePack.suggestedSources.count)
 
-        for (converted, seeded) in zip(pack.suggestedSources, SeedData.defaultSources) {
-            #expect(converted.name == seeded.name)
-            #expect(converted.url == seeded.url)
-            #expect(converted.category == seeded.category)
+        for (converted, compiled) in zip(pack.suggestedSources, KnowledgePack.suggestedSources) {
+            #expect(converted.name == compiled.name)
+            #expect(converted.url == compiled.url)
+            #expect(converted.category == compiled.category)
         }
         // Every suggestion has to be a URL, or it can never become a Source.
         for source in pack.suggestedSources {
@@ -218,15 +218,15 @@ struct BuiltinPacksTests {
                 "the vote-ranked one and r/kaggle, and no more than that on one host")
     }
 
-    /// The Pack file is what a reader's installed record carries; the compiled
-    /// defaults are what actually reaches an install, because `seedIfNeeded`
-    /// runs on every launch and inserts the ones that are missing. A Source in
-    /// only the first of those two would be suggested to nobody, since the
-    /// offer fires when a reader installs a Pack from the library and not on
-    /// the launch-time reinstall a version bump triggers.
-    @Test("the vote-ranked Source is in the list that actually reaches an install")
-    func voteRankedSourceIsSeeded() {
-        #expect(SeedData.defaultSources.contains {
+    /// #46 needed this Source in two lists, because the Pack file reached
+    /// nobody and a compiled array was what launch actually delivered. Since
+    /// #47 there is one list: the Pack file is what a reader's record carries,
+    /// and the record is what both first-launch subscription and the standing
+    /// offer read. `KnowledgePack.suggestedSources` still pins the conversion,
+    /// and delivers nothing.
+    @Test("the vote-ranked Source is in the list that actually reaches a reader")
+    func voteRankedSourceReachesTheReader() throws {
+        #expect(try aiEngineer().suggestedSources.contains {
             $0.url == "https://www.reddit.com/r/MachineLearning/top/.rss?t=week"
                 && $0.category == "LLMs"
         })

--- a/Tests/UnitTests/FeedSyncTests.swift
+++ b/Tests/UnitTests/FeedSyncTests.swift
@@ -277,6 +277,40 @@ struct FeedSyncTests {
                 "a refusal is the worst moment to ask the host again at once")
     }
 
+    /// What the format's cap on suggested Sources actually buys (#20).
+    ///
+    /// `syncAll` fans out one task per host and every one of them is a request
+    /// off the reader's device, so the fan-out is only as bounded as the number
+    /// of Sources is. A Pack used to be able to suggest any number; accepting
+    /// one that suggested five hundred was one tap and five hundred requests.
+    /// `PackFile.maxSuggestedSources` is what stops that, and this is the
+    /// property it is there for — asserted at the worst case the cap allows,
+    /// every Source on a host of its own so none of them share a queue.
+    @Test("a Pack's worth of Sources at the cap opens no more requests than the cap allows")
+    func aPackAtTheCapDoesNotFanOutWithoutBound() async throws {
+        let context = try makeContext()
+        // Hosts of their own, so nothing here is bounded by `HostPacing`: this
+        // is the fan-out with the pacing helping as little as it ever can.
+        let hosts = (0..<PackFile.maxSuggestedSources).map { "cap-\($0).feeds.test" }
+        defer { for host in hosts { StubTransport.stopServing(host: host) } }
+        for (index, host) in hosts.enumerated() {
+            // A path of its own as well as a host: guids are derived from the
+            // path, and thirty Sources sharing one would arrive as one article
+            // thirty readers already had.
+            source(named: "Feed \(index)", host: host, path: "/rss-\(index).xml",
+                   items: 1, in: context)
+        }
+
+        let added = await sync(context)
+
+        #expect(StubTransport.peakConcurrency(among: hosts)
+                <= PackFile.maxSuggestedSources,
+                "the sync opened more requests at once than a Pack may suggest Sources")
+        #expect(hosts.allSatisfy { StubTransport.requests(to: $0).count == 1 },
+                "one Source is one request — a retry would double the fan-out")
+        #expect(added == PackFile.maxSuggestedSources, "and every Source was heard")
+    }
+
     /// The pause is paid between *requests*, so a Source that is never asked
     /// cannot spend it. Without this, an http Source ahead of an https one on
     /// the same host bought the reader a two-second wait for a request no host

--- a/Tests/UnitTests/FeedSyncTests.swift
+++ b/Tests/UnitTests/FeedSyncTests.swift
@@ -279,34 +279,34 @@ struct FeedSyncTests {
 
     /// What the format's cap on suggested Sources actually buys (#20).
     ///
-    /// `syncAll` fans out one task per host and every one of them is a request
-    /// off the reader's device, so the fan-out is only as bounded as the number
-    /// of Sources is. A Pack used to be able to suggest any number; accepting
-    /// one that suggested five hundred was one tap and five hundred requests.
-    /// `PackFile.maxSuggestedSources` is what stops that, and this is the
-    /// property it is there for — asserted at the worst case the cap allows,
-    /// every Source on a host of its own so none of them share a queue.
-    @Test("a Pack's worth of Sources at the cap opens no more requests than the cap allows")
-    func aPackAtTheCapDoesNotFanOutWithoutBound() async throws {
+    /// A cap of thirty makes "at most thirty requests at once" true by
+    /// arithmetic, so asserting *that* would pass against any implementation and
+    /// would still pass if the cap were five hundred. The claim worth pinning is
+    /// the one that can break: at a Pack's worth of Sources, the fan-out is
+    /// bounded by how many *hosts* they sit on and not by how many Sources there
+    /// are (#44). Thirty Sources over ten hosts must be ten requests in flight,
+    /// not thirty — and this fails the moment anything stops grouping by host.
+    @Test("a Pack's worth of Sources is still fetched a host at a time, not all at once")
+    func aPackAtTheCapFansOutByHostNotBySource() async throws {
         let context = try makeContext()
-        // Hosts of their own, so nothing here is bounded by `HostPacing`: this
-        // is the fan-out with the pacing helping as little as it ever can.
-        let hosts = (0..<PackFile.maxSuggestedSources).map { "cap-\($0).feeds.test" }
+        let hostCount = 10
+        let hosts = (0..<hostCount).map { "cap-\($0).feeds.test" }
         defer { for host in hosts { StubTransport.stopServing(host: host) } }
-        for (index, host) in hosts.enumerated() {
+        // Three Sources per host, so Sources outnumber hosts three to one and
+        // the two possible bounds are far enough apart to tell apart.
+        for index in 0..<PackFile.maxSuggestedSources {
             // A path of its own as well as a host: guids are derived from the
-            // path, and thirty Sources sharing one would arrive as one article
-            // thirty readers already had.
-            source(named: "Feed \(index)", host: host, path: "/rss-\(index).xml",
-                   items: 1, in: context)
+            // path, and Sources sharing one would arrive as one article the
+            // reader already had.
+            source(named: "Feed \(index)", host: hosts[index % hostCount],
+                   path: "/rss-\(index).xml", items: 1, in: context)
         }
 
         let added = await sync(context)
 
-        #expect(StubTransport.peakConcurrency(among: hosts)
-                <= PackFile.maxSuggestedSources,
-                "the sync opened more requests at once than a Pack may suggest Sources")
-        #expect(hosts.allSatisfy { StubTransport.requests(to: $0).count == 1 },
+        #expect(StubTransport.peakConcurrency(among: hosts) <= hostCount,
+                "the sync opened more requests at once than there are hosts to ask")
+        #expect(hosts.allSatisfy { StubTransport.requests(to: $0).count == 3 },
                 "one Source is one request — a retry would double the fan-out")
         #expect(added == PackFile.maxSuggestedSources, "and every Source was heard")
     }

--- a/Tests/UnitTests/PackFileTests.swift
+++ b/Tests/UnitTests/PackFileTests.swift
@@ -39,6 +39,14 @@ struct PackFileTests {
         }
     }
 
+    /// Suggestions on distinct hosts, so a count is all that separates them —
+    /// the cap counts Sources, not the servers behind them.
+    private func sources(_ count: Int) -> [PackFile.PackSource] {
+        (0..<count).map {
+            .init(name: "Feed \($0)", url: "https://feed-\($0).test/rss", category: "LLMs")
+        }
+    }
+
     /// The error thrown by `validate`, or `nil` if it accepted the Pack.
     private func rejection(_ file: PackFile) -> PackValidationError? {
         reason { try PackValidator.validate(file) }
@@ -311,6 +319,32 @@ struct PackFileTests {
         #expect(error?.errorDescription?.contains("\(over)") == true)
     }
 
+    @Test("a Pack suggesting more Sources than the format allows is rejected, naming the count")
+    func rejectsTooManySuggestedSources() {
+        let over = PackFile.maxSuggestedSources + 1
+        let file = pack(suggestedSources: sources(over))
+
+        let error = rejection(file)
+        #expect(error == .tooManySuggestedSources(over))
+        #expect(error?.errorDescription?.contains("\(over)") == true)
+    }
+
+    @Test("a Pack at exactly the suggested-Source limit is accepted")
+    func acceptsSuggestedSourceLimit() throws {
+        try PackValidator.validate(pack(suggestedSources: sources(PackFile.maxSuggestedSources)))
+    }
+
+    /// The cap is on the file, so it is enforced on the way in from bytes and
+    /// not only against a `PackFile` some other code already built. An import
+    /// is the only way an over-cap Pack can reach a reader at all.
+    @Test("an over-cap Pack is rejected on decode, not merely on validate")
+    func rejectsTooManySuggestedSourcesOnDecode() throws {
+        let over = PackFile.maxSuggestedSources + 1
+        let data = try JSONEncoder().encode(pack(suggestedSources: sources(over)))
+
+        #expect(decodeRejection(data) == .tooManySuggestedSources(over))
+    }
+
     @Test("a Pack at exactly the Cluster limit is accepted")
     func acceptsClusterLimit() throws {
         let file = pack(clusterOrder: (0..<PackFile.maxClusters).map { "Cluster \($0)" },
@@ -400,6 +434,7 @@ struct PackFileTests {
     func everyReasonIsReadable() {
         let reasons: [PackValidationError] = [
             .unsupportedVersion(9), .noConcepts, .tooManyConcepts(999), .badClusterCount(0),
+            .tooManySuggestedSources(500),
             .emptyDefinition("A"),
             // Both readings of one case: the same name twice, and two
             // spellings of it. They word themselves differently.

--- a/Tests/UnitTests/PackSelectionTests.swift
+++ b/Tests/UnitTests/PackSelectionTests.swift
@@ -59,6 +59,17 @@ struct PackSelectionTests {
         }
     }
 
+    /// The format caps what a Pack may suggest (#20). The Packs that ship in
+    /// the app have to sit inside their own format — and comfortably, or the
+    /// cap is a budget rather than a bound on the absurd.
+    @Test("every built-in Pack suggests fewer Sources than the format allows")
+    func builtinsAreInsideTheSuggestionCap() throws {
+        for builtin in BuiltinPacks.all {
+            #expect(builtin.pack.suggestedSources.count <= PackFile.maxSuggestedSources,
+                    "“\(builtin.pack.field)” suggests more Sources than a Pack may")
+        }
+    }
+
     @Test("the Security Engineering Pack draws a real map, with a side-quest lane")
     func securityPackIsAMap() throws {
         let pack = try security()
@@ -310,6 +321,47 @@ struct PackSelectionTests {
         // And the reader's own name for the Source they had survives.
         let names = try context.fetch(FetchDescriptor<FeedSource>()).map(\.name)
         #expect(names.contains("My own name for it"))
+    }
+
+    // MARK: - What the offer opens with ticked
+
+    /// Pre-checking is consent by default, so it is bounded too (#20). A Pack
+    /// at the format's cap must not open with thirty Sources ticked and one tap
+    /// standing between the reader and thirty subscriptions.
+    /// Suggestions on distinct hosts, so a count is all that separates them.
+    private func suggestions(_ count: Int) -> [PackFile.PackSource] {
+        (0..<count).map {
+            .init(name: "Feed \($0)", url: "https://feed-\($0).test/rss", category: "LLMs")
+        }
+    }
+
+    @Test("a short offer opens with every suggestion ticked")
+    func shortOfferOpensTicked() throws {
+        let short = suggestions(PackSourceOfferView.preCheckedUpTo)
+
+        #expect(PackSourceOfferView.preChecked(short) == Set(short.map(\.url)))
+    }
+
+    @Test("an offer past the threshold opens with nothing ticked, not with the first fifteen")
+    func longOfferOpensUnticked() throws {
+        let long = suggestions(PackSourceOfferView.preCheckedUpTo + 1)
+
+        // Empty, so "Add 0" is disabled and the reader has to say which ones.
+        // Not a prefix: the order suggestions arrive in is the author's, not a
+        // ranking the app may read as consent.
+        #expect(PackSourceOfferView.preChecked(long).isEmpty)
+    }
+
+    /// The threshold is set from the shipped Packs, so it has to keep holding
+    /// them. A built-in that grew past it would quietly stop opening ticked —
+    /// and the switch-Pack journey taps "Add" without ticking anything.
+    @Test("every built-in Pack's offer still opens ticked")
+    func builtinOffersOpenTicked() throws {
+        for builtin in BuiltinPacks.all {
+            let sources = builtin.pack.suggestedSources
+            #expect(PackSourceOfferView.preChecked(sources).count == sources.count,
+                    "“\(builtin.pack.field)” now suggests too many Sources to open ticked")
+        }
     }
 
     @Test("a suggestion that could never be fetched is never offered")

--- a/Tests/UnitTests/PackSelectionTests.swift
+++ b/Tests/UnitTests/PackSelectionTests.swift
@@ -324,10 +324,12 @@ struct PackSelectionTests {
     }
 
     // MARK: - What the offer opens with ticked
+    //
+    // Pre-checking is consent by default, so it is bounded too (#20). A Pack at
+    // the format's cap must not open with thirty Sources ticked and one tap
+    // standing between the reader and thirty subscriptions. What an *unticked*
+    // box means once that happens is `SourceAcquisitionTests`' half of this.
 
-    /// Pre-checking is consent by default, so it is bounded too (#20). A Pack
-    /// at the format's cap must not open with thirty Sources ticked and one tap
-    /// standing between the reader and thirty subscriptions.
     /// Suggestions on distinct hosts, so a count is all that separates them.
     private func suggestions(_ count: Int) -> [PackFile.PackSource] {
         (0..<count).map {
@@ -337,19 +339,19 @@ struct PackSelectionTests {
 
     @Test("a short offer opens with every suggestion ticked")
     func shortOfferOpensTicked() throws {
-        let short = suggestions(PackSourceOfferView.preCheckedUpTo)
+        let short = suggestions(PackSourceOffer.preCheckedUpTo)
 
-        #expect(PackSourceOfferView.preChecked(short) == Set(short.map(\.url)))
+        #expect(PackSourceOffer.preChecked(short) == Set(short.map(\.url)))
     }
 
     @Test("an offer past the threshold opens with nothing ticked, not with the first fifteen")
     func longOfferOpensUnticked() throws {
-        let long = suggestions(PackSourceOfferView.preCheckedUpTo + 1)
+        let long = suggestions(PackSourceOffer.preCheckedUpTo + 1)
 
         // Empty, so "Add 0" is disabled and the reader has to say which ones.
         // Not a prefix: the order suggestions arrive in is the author's, not a
         // ranking the app may read as consent.
-        #expect(PackSourceOfferView.preChecked(long).isEmpty)
+        #expect(PackSourceOffer.preChecked(long).isEmpty)
     }
 
     /// The threshold is set from the shipped Packs, so it has to keep holding
@@ -359,7 +361,7 @@ struct PackSelectionTests {
     func builtinOffersOpenTicked() throws {
         for builtin in BuiltinPacks.all {
             let sources = builtin.pack.suggestedSources
-            #expect(PackSourceOfferView.preChecked(sources).count == sources.count,
+            #expect(PackSourceOffer.preChecked(sources).count == sources.count,
                     "“\(builtin.pack.field)” now suggests too many Sources to open ticked")
         }
     }

--- a/Tests/UnitTests/SourceAcquisitionTests.swift
+++ b/Tests/UnitTests/SourceAcquisitionTests.swift
@@ -186,6 +186,74 @@ struct SourceAcquisitionTests {
             .map(\.url).contains(one.url))
     }
 
+    // MARK: - What a Pack may ask for (#20)
+
+    /// A Pack that is a map only incidentally: one Concept, and as many
+    /// suggested Sources as the test is about. Every suggestion is on a host of
+    /// its own, so nothing here turns on two of them sharing one.
+    private func packSuggesting(_ count: Int) -> PackFile {
+        PackFile(field: "Everything",
+                 specialtyCluster: nil,
+                 clusterOrder: ["Foundations"],
+                 concepts: [.init(name: "Attention", cluster: "Foundations",
+                                  definition: "Weighted lookup.", dependencies: [])],
+                 stages: [],
+                 suggestedSources: (0..<count).map {
+                     .init(name: "Feed \($0)", url: "https://feed-\($0).test/rss",
+                           category: "LLMs")
+                 })
+    }
+
+    /// An imported Pack is a file from outside the app, and the format is where
+    /// it is told no. A Pack carrying more suggestions than
+    /// `PackFile.maxSuggestedSources` never gets as far as the offer sheet, so
+    /// the reader is never one tap from hundreds of subscriptions — and never
+    /// one cold sync from hundreds of requests off their device.
+    @Test("a Pack suggesting more Sources than the format allows is rejected, and subscribes nothing")
+    func anOverCapImportSubscribesNothing() throws {
+        let context = try makeContext()
+        let pack = try aiEngineer()
+        try PackInstaller.install(pack, origin: .builtin, context: context)
+        SeedData.acquireSourcesIfNeeded(context: context)
+        let before = try subscribedURLs(context)
+
+        let over = PackFile.maxSuggestedSources + 1
+        let greedy = packSuggesting(over)
+
+        // Through the bytes, because that is what importing a file actually is.
+        #expect(throws: PackValidationError.tooManySuggestedSources(over)) {
+            _ = try PackValidator.decodeAndValidate(try JSONEncoder().encode(greedy))
+        }
+
+        // Nothing was installed, so nothing is subscribed — and the record the
+        // standing offer reads is still the flagship's, so none of the thirty-one
+        // can be raised at a later launch either.
+        #expect(try subscribedURLs(context) == before)
+        let active = try #require(ActivePack.load(context: context))
+        #expect(active.field == "AI Engineering")
+        #expect(active.suggestedSources.map(\.url) == pack.suggestedSources.map(\.url))
+        #expect(try standing(active.suggestedSources, context).isEmpty)
+    }
+
+    /// The other side of the cap: at it, an import still works. A bound that
+    /// also turned away the largest legal Pack would be off by one.
+    @Test("a Pack at the cap installs, and offers exactly what it suggests")
+    func aPackAtTheCapIsOffered() throws {
+        let context = try makeContext()
+        let atCap = packSuggesting(PackFile.maxSuggestedSources)
+
+        let decoded = try PackValidator.decodeAndValidate(try JSONEncoder().encode(atCap))
+        try PackInstaller.install(decoded, origin: .imported, context: context)
+
+        // Offered, not subscribed — an import is still an offer (ADR-0011).
+        #expect(PackSourceOffer.pending(decoded.suggestedSources, context: context).count
+                == PackFile.maxSuggestedSources)
+        #expect(try context.fetch(FetchDescriptor<FeedSource>()).isEmpty)
+        // And the offer at that size opens with nothing ticked, so accepting it
+        // wholesale is not one tap.
+        #expect(PackSourceOfferView.preChecked(decoded.suggestedSources).isEmpty)
+    }
+
     // MARK: - Retirement
 
     @Test("a Source that turned out dead is removed, and does not re-seed the store")

--- a/Tests/UnitTests/SourceAcquisitionTests.swift
+++ b/Tests/UnitTests/SourceAcquisitionTests.swift
@@ -251,7 +251,59 @@ struct SourceAcquisitionTests {
         #expect(try context.fetch(FetchDescriptor<FeedSource>()).isEmpty)
         // And the offer at that size opens with nothing ticked, so accepting it
         // wholesale is not one tap.
-        #expect(PackSourceOfferView.preChecked(decoded.suggestedSources).isEmpty)
+        #expect(PackSourceOffer.preChecked(decoded.suggestedSources).isEmpty)
+    }
+
+    // MARK: - What an unticked box means (#20, ADR-0011)
+
+    /// ADR-0011: an unticked box counts as an answer *because* the sheet
+    /// arrives pre-ticked. This is that flow, unchanged — a short offer still
+    /// buries what the reader deliberately unticked.
+    @Test("on an offer that opened ticked, unticking one still declines it")
+    func untickingAShortOfferDeclines() throws {
+        let context = try makeContext()
+        let offered = packSuggesting(PackSourceOffer.preCheckedUpTo).suggestedSources
+        let kept = Set(offered.dropLast().map(\.url))
+
+        #expect(PackSourceOffer.accept(kept, of: offered, context: context)
+                == offered.count - 1)
+
+        // The one left unticked was ticked when the sheet opened, so leaving it
+        // that way was deliberate, and the standing offer stops raising it.
+        #expect(try standing(offered, context).isEmpty)
+    }
+
+    /// The premise ADR-0011's rule rests on is gone above `preCheckedUpTo`:
+    /// nothing arrives ticked, so ticking three of thirty-one says nothing
+    /// whatever about the other twenty-eight. Recording those as declined would
+    /// bury them close to permanently on a list the reader never saw ticked —
+    /// which is the consent problem #20 exists to fix, not to deepen.
+    @Test("on an offer that opened unticked, the ones not ticked are unanswered, not declined")
+    func longOfferLeavesTheRestUnanswered() throws {
+        let context = try makeContext()
+        let offered = packSuggesting(PackSourceOffer.preCheckedUpTo + 3).suggestedSources
+        #expect(!PackSourceOffer.opensTicked(offered), "this offer must open unticked")
+        let taken = Set(offered.prefix(3).map(\.url))
+
+        #expect(PackSourceOffer.accept(taken, of: offered, context: context) == 3)
+
+        // The three are subscribed; the rest are still on offer rather than
+        // buried, and nothing at all was recorded as declined.
+        #expect(try subscribedURLs(context) == taken)
+        #expect(try standing(offered, context).map(\.url) == offered.dropFirst(3).map(\.url))
+        #expect(PackSourceOffer.declined.isEmpty)
+    }
+
+    /// "Not now" is the way to refuse a long offer outright, and it is
+    /// untouched — a reader who means to say no to all of it still can.
+    @Test("declining a long offer outright still records every suggestion")
+    func decliningALongOfferStillRecordsIt() throws {
+        let context = try makeContext()
+        let offered = packSuggesting(PackSourceOffer.preCheckedUpTo + 3).suggestedSources
+
+        PackSourceOffer.recordDeclined(offered)
+
+        #expect(try standing(offered, context).isEmpty)
     }
 
     // MARK: - Retirement

--- a/Tests/UnitTests/SourceAcquisitionTests.swift
+++ b/Tests/UnitTests/SourceAcquisitionTests.swift
@@ -1,0 +1,244 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import TechPulse
+
+/// How a Source is acquired (#47, ADR-0011).
+///
+/// Two mechanisms used to deliver Sources and disagree about consent: an offer
+/// that subscribed to nothing, and a launch-time seeder that subscribed to
+/// everything from a compiled AI list regardless of which Pack the reader was
+/// on. These are the rules that replaced the second one.
+@MainActor
+@Suite("Acquiring a Source", .serialized)
+struct SourceAcquisitionTests {
+
+    private func makeContext() throws -> ModelContext {
+        let container = try AppSchema.inMemoryContainer()
+        ActivePack.resetCache()
+        PackSourceOffer.forgetDeclined()
+        return ModelContext(container)
+    }
+
+    private func aiEngineer() throws -> PackFile { try BuiltinPacks.aiEngineer() }
+
+    private func security() throws -> PackFile {
+        try BuiltinPacks.load(BuiltinPacks.securityEngineeringFileName)
+    }
+
+    private func subscribedURLs(_ context: ModelContext) throws -> Set<String> {
+        Set(try context.fetch(FetchDescriptor<FeedSource>()).map(\.url.absoluteString))
+    }
+
+    /// The standing offer as `SettingsView` computes it — off the Sources the
+    /// view already holds, rather than a fetch of its own.
+    private func standing(_ suggestions: [PackFile.PackSource],
+                          _ context: ModelContext) throws -> [PackFile.PackSource] {
+        PackSourceOffer.standing(suggestions, subscribedTo: try subscribedURLs(context))
+    }
+
+    // MARK: - The first launch
+
+    @Test("a store with nothing to read is subscribed to the Active Pack's suggestions")
+    func firstLaunchSubscribes() throws {
+        let context = try makeContext()
+        let pack = try aiEngineer()
+        try PackInstaller.install(pack, origin: .builtin, context: context)
+
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        #expect(try subscribedURLs(context) == Set(pack.suggestedSources.map(\.url)))
+        // And nothing is left on offer, because it was all taken.
+        #expect(try standing(pack.suggestedSources, context).isEmpty)
+    }
+
+    @Test("the Pack the reader is on decides which Sources arrive, not a compiled AI list")
+    func suggestionsFollowTheActivePack() throws {
+        let context = try makeContext()
+        let pack = try security()
+        try PackInstaller.install(pack, origin: .builtin, context: context)
+
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        let subscribed = try subscribedURLs(context)
+        #expect(subscribed == Set(pack.suggestedSources.map(\.url)))
+        // The sharper edge of #47: a Security Engineering reader used to
+        // receive arXiv cs.AI, OpenAI News and r/kaggle without being asked.
+        for flagship in try aiEngineer().suggestedSources {
+            #expect(!subscribed.contains(flagship.url),
+                    "the flagship's “\(flagship.name)” reached a Security Engineering reader")
+        }
+    }
+
+    // MARK: - Every launch after the first
+
+    @Test("a Source added to a Pack in a new app version is offered, never subscribed")
+    func laterArrivalsAreOfferedNotSubscribed() throws {
+        let context = try makeContext()
+        let pack = try aiEngineer()
+        try PackInstaller.install(pack, origin: .builtin, context: context)
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        // A reader whose store predates one of the Pack's Sources — exactly
+        // what #46 created by adding the vote-ranked feed to a shipped Pack.
+        let arrival = try #require(pack.suggestedSources.first {
+            $0.url.contains("r/MachineLearning")
+        })
+        let existing = try context.fetch(FetchDescriptor<FeedSource>())
+        let row = try #require(existing.first { $0.url.absoluteString == arrival.url })
+        context.delete(row)
+        try context.save()
+
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        #expect(!(try subscribedURLs(context)).contains(arrival.url),
+                "launch subscribed the reader to a Source they were never offered")
+        #expect(try standing(pack.suggestedSources, context)
+            .map(\.url) == [arrival.url])
+    }
+
+    @Test("a launch that adds nothing still leaves the reader's Sources alone")
+    func laterLaunchesChangeNothing() throws {
+        let context = try makeContext()
+        try PackInstaller.install(try aiEngineer(), origin: .builtin, context: context)
+        SeedData.acquireSourcesIfNeeded(context: context)
+        let after = try subscribedURLs(context)
+
+        SeedData.acquireSourcesIfNeeded(context: context)
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        #expect(try subscribedURLs(context) == after)
+        #expect(try context.fetch(FetchDescriptor<FeedSource>()).count == after.count)
+    }
+
+    @Test("switching Pack does not hand the reader the new Pack's Sources unasked")
+    func switchingPackOffersRatherThanSubscribes() throws {
+        let context = try makeContext()
+        try PackInstaller.install(try aiEngineer(), origin: .builtin, context: context)
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        let securityPack = try security()
+        try PackInstaller.install(securityPack, origin: .builtin, context: context)
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        let subscribed = try subscribedURLs(context)
+        for suggestion in securityPack.suggestedSources {
+            #expect(!subscribed.contains(suggestion.url))
+        }
+        #expect(try standing(securityPack.suggestedSources, context).count
+                == securityPack.suggestedSources.count)
+    }
+
+    // MARK: - Turning an offer down
+
+    @Test("a suggestion the reader turned down stops being raised")
+    func declinedSuggestionsAreNotRaisedAgain() throws {
+        let context = try makeContext()
+        let pack = try security()
+
+        #expect(try standing(pack.suggestedSources, context).count
+                == pack.suggestedSources.count)
+
+        PackSourceOffer.recordDeclined(pack.suggestedSources)
+
+        #expect(try standing(pack.suggestedSources, context).isEmpty)
+        // Turning an offer down subscribes to nothing, the same as ignoring it.
+        #expect(try context.fetch(FetchDescriptor<FeedSource>()).isEmpty)
+    }
+
+    @Test("turning one suggestion down leaves the rest on offer")
+    func decliningIsPerSuggestion() throws {
+        let context = try makeContext()
+        let pack = try security()
+        let refused = pack.suggestedSources[0]
+
+        PackSourceOffer.recordDeclined([refused])
+
+        let offered = try standing(pack.suggestedSources, context)
+        #expect(!offered.map(\.url).contains(refused.url))
+        #expect(offered.count == pack.suggestedSources.count - 1)
+    }
+
+    @Test("installing the Pack by hand asks again, which is the way back from a decline")
+    func installingByHandAsksAgain() throws {
+        let context = try makeContext()
+        let pack = try security()
+        PackSourceOffer.recordDeclined(pack.suggestedSources)
+
+        // `PackLibraryView` offers `pending`, not `standing`: choosing a Pack
+        // from the library is the reader asking to see its Sources.
+        #expect(PackSourceOffer.pending(pack.suggestedSources, context: context).count
+                == pack.suggestedSources.count)
+        #expect(try standing(pack.suggestedSources, context).isEmpty)
+    }
+
+    @Test("a decline never hides a Source the reader went on to subscribe to")
+    func decliningThenSubscribingLeavesNoOffer() throws {
+        let context = try makeContext()
+        let pack = try security()
+        let one = pack.suggestedSources[0]
+
+        PackSourceOffer.recordDeclined([one])
+        PackSourceOffer.subscribe([one], context: context)
+
+        #expect(try subscribedURLs(context).contains(one.url))
+        #expect(!(try standing(pack.suggestedSources, context))
+            .map(\.url).contains(one.url))
+    }
+
+    // MARK: - Retirement
+
+    @Test("a Source that turned out dead is removed, and does not re-seed the store")
+    func retiredSourceIsSweptWithoutReseeding() throws {
+        let context = try makeContext()
+        let pack = try aiEngineer()
+        try PackInstaller.install(pack, origin: .builtin, context: context)
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        let dead = URL(string: "https://medium.com/feed/kaggle-blog")!
+        context.insert(FeedSource(name: "Kaggle Blog", url: dead, category: "Data Science"))
+        try context.save()
+
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        #expect(!(try subscribedURLs(context)).contains(dead.absoluteString))
+        #expect(try subscribedURLs(context) == Set(pack.suggestedSources.map(\.url)))
+    }
+
+    @Test("a store that held Sources is never re-seeded, even if retirement empties it")
+    func retirementNeverReopensTheFirstLaunch() throws {
+        let context = try makeContext()
+        let pack = try aiEngineer()
+        try PackInstaller.install(pack, origin: .builtin, context: context)
+        context.insert(FeedSource(name: "Kaggle Blog",
+                                  url: URL(string: "https://medium.com/feed/kaggle-blog")!,
+                                  category: "Data Science"))
+        try context.save()
+
+        SeedData.acquireSourcesIfNeeded(context: context)
+
+        // The reader is left with nothing, which is theirs to fix. Handing back
+        // fourteen Sources they were never offered would be the behaviour this
+        // whole path exists to stop.
+        #expect(try context.fetch(FetchDescriptor<FeedSource>()).isEmpty)
+        #expect(try standing(pack.suggestedSources, context).count
+                == pack.suggestedSources.count)
+    }
+
+    // MARK: - Through launch
+
+    @Test("launch settles the Pack before it decides which Sources to offer")
+    func launchSeedsAgainstTheInstalledPack() throws {
+        let context = try makeContext()
+        // A reader who chose Security Engineering on an earlier run. Launch has
+        // to reinstate that Pack before reading suggestions off it, or the
+        // flagship's Sources arrive instead.
+        try PackInstaller.install(try security(), origin: .builtin, context: context)
+
+        SeedData.seedIfNeeded(context: context)
+
+        let subscribed = try subscribedURLs(context)
+        #expect(subscribed == Set(try security().suggestedSources.map(\.url)))
+        #expect(ActivePack.load(context: context)?.field == "Security Engineering")
+    }
+}

--- a/Tests/UnitTests/StubTransport.swift
+++ b/Tests/UnitTests/StubTransport.swift
@@ -165,6 +165,12 @@ final class StubTransport: URLProtocol, @unchecked Sendable {
     /// is how "these never overlapped" is asked; naming a pair is how "these
     /// did" is.
     static func peakConcurrency(among hosts: String...) -> Int {
+        peakConcurrency(among: hosts)
+    }
+
+    /// The same question of a list too long to name one host at a time — a
+    /// fan-out the size of `PackFile.maxSuggestedSources`, say.
+    static func peakConcurrency(among hosts: [String]) -> Int {
         let wanted = Set(hosts.map(key))
         let spans = state.withLock { $0.spans.filter { wanted.contains($0.host) } }
         // A request still open counts up to now. Ends sort before starts at the

--- a/docs/adr/0011-a-source-is-offered-not-delivered.md
+++ b/docs/adr/0011-a-source-is-offered-not-delivered.md
@@ -114,11 +114,26 @@ who declines a URL under one Pack is never raised it under another, and the
 built-in Packs are disjoint today only by chance. Installing that Pack by hand
 still offers it, which is the escape hatch.
 
-**An unchecked box counts as an answer, in both flows.** Accepting an offer
-records the suggestions left unticked as declined, and the sheet arrives
-pre-ticked, so unticking is deliberate. Without this the reader would untick
-three Sources, tap Add, and find those exact three waiting in Settings. It does
-change the library flow, which previously forgot the whole question on dismissal.
+**An unchecked box counts as an answer wherever the box arrived checked.**
+Accepting an offer records the suggestions left unticked as declined, because
+the sheet arrives pre-ticked and unticking is therefore deliberate. Without this
+the reader would untick three Sources, tap Add, and find those exact three
+waiting in Settings. It does change the library flow, which previously forgot
+the whole question on dismissal. Where an offer is long enough to arrive with
+nothing ticked, the premise is absent and so is the conclusion: leaving a
+suggestion unticked says nothing about it, and it stays in the standing offer.
+See `PackSourceOffer.preCheckedUpTo`.
+
+**Correction (2026-08-22):** this consequence read "**An unchecked box counts as
+an answer, in both flows.** Accepting an offer records the suggestions left
+unticked as declined, and the sheet arrives pre-ticked, so unticking is
+deliberate." That was true of every offer the app could then make, because every
+offer arrived pre-ticked. #20 capped what a Pack may suggest and stopped
+pre-ticking offers past `PackSourceOffer.preCheckedUpTo`, which removed the
+premise the rule rests on without narrowing the rule — so a reader who ticked
+three of thirty-one silently declined the other twenty-eight, close to
+permanently, on a list they were never shown as ticked. The decision stands; the
+sentence was an absolute that stopped being true.
 
 **Declines made before this shipped were not recorded, so they are asked once
 more.** A reader who hand-installed a Pack on an earlier build and tapped "Not

--- a/docs/adr/0011-a-source-is-offered-not-delivered.md
+++ b/docs/adr/0011-a-source-is-offered-not-delivered.md
@@ -1,0 +1,134 @@
+# A Source is offered, not delivered
+
+Two mechanisms put Sources in front of a reader, and they disagreed about
+consent.
+
+`PackSourceOffer` **offered**. Its sheet said so in as many words — *"Nothing is
+subscribed until you say so"* — and `PackInstaller` deliberately subscribed to
+nothing, leaving a Pack's suggestions on the record for the app to put to the
+reader.
+
+`SeedData.seedIfNeeded` **subscribed**. It ran from `TechPulseApp` on every
+launch and inserted any entry of `SeedData.defaultSources` the store did not
+already have, so that *"app updates deliver new feeds to existing installs"*.
+
+The seeder was the one that actually reached anybody. The offer fires when a
+reader installs a Pack **from the library by hand**, not on the launch-time
+reinstall a `builtinPackVersion` bump triggers — so a Source added to a shipped
+Pack reached nobody through the Pack file, and everybody through the array
+(#46).
+
+That cost three things at once.
+
+- A Source added to `defaultSources` **arrived in a reader's Settings without
+  their ever being asked**.
+- Because `PackSourceOffer.pending` filters out URLs already subscribed, the
+  arrival **suppressed the offer for that Source permanently**. The reader could
+  never be asked, because they already had it. The consent gap closed itself.
+- `defaultSources` was the **AI** list and `seedIfNeeded` was not conditioned on
+  the Active Pack, so a reader who chose Security Engineering still received
+  arXiv cs.AI, OpenAI News and r/kaggle. The Pack chooser let a reader pick a
+  field; the seeder ignored the choice.
+
+**Decision:** a Source is offered. The Pack a reader is on is what suggests, and
+the reader is what subscribes.
+
+- **The Pack file is the only list anything reads.** `SeedData.defaultSources`
+  is gone; suggestions are read off `ActivePack.inUse.suggestedSources` — the
+  installed record — so a Security Engineering reader is asked about Security
+  Engineering. The *text* of the flagship's list still exists in a second place,
+  as a test fixture; what ended is a second place that could deliver it.
+- **The first launch of an empty store subscribes what the Active Pack
+  suggests.** This is the one exception, and it is bounded by having nothing to
+  read: an offer needs a Feed to be weighed against, and an empty app is a worse
+  first impression than a Source too many. Settings is one tap away.
+- **Every launch after that subscribes nothing.** A Source arriving in a new
+  version of a Pack becomes a **standing offer**, surfaced as a row in Settings,
+  and waits there until the reader answers it.
+- **A suggestion turned down is not raised again.** Declines are recorded, and
+  only the standing offer consults that record.
+
+## Considered options
+
+- **Keep seeding, but scope it to the Active Pack.** Free, and it fixes the
+  sharpest edge: the Security Engineering reader stops receiving AI Sources.
+  Rejected as a stopping point rather than as a step — it leaves the app
+  subscribing readers to Sources they were never asked about, now merely pointed
+  at the right Pack. The glossary says a Source is "chosen by the user", and
+  this keeps that false.
+- **Offer everything, including the first launch.** The strictest reading, and
+  the one with no exception to explain. Rejected: a new install would open on an
+  empty Feed behind a sheet the reader has no way to evaluate — they have not
+  seen the app yet, and the Sources are the app. The consent this protects is
+  worth less than the first run it costs, and the reader can turn any of them
+  off in the same screen the offer would have sent them to.
+- **Surface the offer at launch, as a sheet.** More likely to be seen than a
+  Settings row. Rejected: launch is the moment the reader came to read, and a
+  modal in front of the Feed to ask about a Source they did not know they wanted
+  is a worse trade than a row that waits. A row also survives being ignored,
+  which a sheet does not.
+- **Record declines in the store rather than `UserDefaults`.** Rejected: a
+  decline is about what the reader has been *asked*, not about what their map
+  contains, and it has to outlive a Pack being reinstalled over the top — which
+  is the same reason `ActivePackIdentity` lives there.
+
+## Consequences
+
+**A Source added to a Pack now reaches existing readers slowly, or not at all.**
+That is the point, but it is a real cost: a suggestion that would once have
+appeared in every install on the next launch now waits behind a row that a
+reader may never tap. Anything that *must* reach a reader is not a suggestion
+and cannot be shipped as one.
+
+**The offer is only as visible as the Settings row.** Nothing else surfaces it —
+no badge, no launch prompt. If a Pack ever ships a suggestion that matters, this
+is the constraint to revisit first, and the ADR to supersede.
+
+**A decline is close to permanent.** The only way back is installing that Pack
+from the library, which re-offers everything, because choosing a Pack by hand is
+a reader asking to see its Sources. There is deliberately no "show me what I
+turned down" screen — turning something down should not create a second list to
+maintain. A reader who wants a specific Source back can also add it themselves.
+
+**Sources a reader already received unasked are left alone.** A Security
+Engineering reader who was handed the flagship's Sources before this keeps them:
+Settings can only toggle a Source, not delete one, and deleting subscriptions
+out from under a reader — along with the Articles that point at them — is a
+worse thing to do than the one being corrected. They stop *arriving*; the ones
+that arrived stay, and can be switched off.
+
+**`KnowledgePack.suggestedSources` still exists, and delivers nothing.** The
+compiled AI list survives as the fixture `BuiltinPacksTests` compares
+`ai-engineer.json` against, next to `concepts` and `stages`, so the conversion
+cannot silently drop a Source. What made #46 subtle was not that the list was
+duplicated — it was that one copy was *also* the delivery path. Only one copy is
+now readable at runtime.
+
+**A decline names a URL, not a URL within a Pack.** Turning down a suggestion
+suppresses the standing offer for that URL whichever Pack later suggests it. That
+matches how the rest of this works — `pending` matches a subscription by URL and
+ignores which Pack it came from, because a Source is the reader's rather than the
+Pack's — and it reads the decline as "I do not want this to be one of my
+Sources", which is what the reader was actually asked. It is not free: a reader
+who declines a URL under one Pack is never raised it under another, and the
+built-in Packs are disjoint today only by chance. Installing that Pack by hand
+still offers it, which is the escape hatch.
+
+**An unchecked box counts as an answer, in both flows.** Accepting an offer
+records the suggestions left unticked as declined, and the sheet arrives
+pre-ticked, so unticking is deliberate. Without this the reader would untick
+three Sources, tap Add, and find those exact three waiting in Settings. It does
+change the library flow, which previously forgot the whole question on dismissal.
+
+**Declines made before this shipped were not recorded, so they are asked once
+more.** A reader who hand-installed a Pack on an earlier build and tapped "Not
+now" left nothing behind for `standing` to consult, and that Pack's suggestions
+surface in Settings on their first upgraded launch. One row, once, and it
+self-corrects the moment they answer it. Migrating it is not possible — the
+information was never written down — and "not now" was a fair description of what
+that button meant at the time.
+
+**`seedIfNeeded` installs the Pack before it touches Sources.** Which Sources a
+reader should be offered comes from the Pack they are on, and which Pack that is
+is only settled by `PackMigration.ensureBuiltinInstalled`. Anything added to
+launch that acquires Sources has to run after it.


### PR DESCRIPTION
Closes #53.

## Why #48 was not enough

#48 closed three call sites that read a control twice. It closed nothing structurally: `find.label` still compiled, and the next wait anyone wrote was one keystroke from the same thrown query — which reads as a broken journey rather than a failing one, and so gets retried and shrugged at rather than diagnosed. That is how it lasted: `testCoreJourney` failed about one run in two and was read as flake.

## The seam

`journey.waitUntil` now takes the element as a **parameter** and hands the condition an `ElementState?`:

```swift
journey.waitUntil(know, "the Concept never became Known") { $0?.isEnabled == false }
```

`label`, `isEnabled` and `isSelected` come from one snapshot, so a condition holding one has no element left to ask a second question of.

**Existence is the optional, not a field.** The ticket sketched `exists` as a third attribute; a control that has gone has no snapshot to report, so `nil` already carries what `!exists` carried — in the one place a condition can still see it.

## What makes it a seam rather than a helper

The deletion. Every condition in the journeys turned out to be about exactly **one** control, so the raw `() -> Bool` wait had nothing left needing it — and with it gone there is nowhere to write the two-query shape. `becomesTrue` went the same way, replaced by `appears` for the four soft existence checks. `poll` stays private.

That survey is the whole difference between this and the lint the ticket weighed it against. A lint catches the shape where it looks for it; a wait that never offers the shape catches it everywhere, including in code nobody has written yet. The lint was never prototyped and did not need to be — it would have cost a tool, a config, and a rule that only ever catches the spellings it was taught.

**Thirteen call sites converted**, nine reading an attribute, plus three assertions *outside* a wait that could still throw. The feed's sync-banner wait turned out to be a `waitUntilGone` wearing a closure.

## The bug the review caught

Rewriting `waitUntilGone` as `{ $0 == nil }` on the new wait was tidy and wrong. `try?` swallows **every** snapshot failure, not just "no matches" — so an app too busy to answer would have read as *dismissed* and passed. An assertion that passes when something is gone must not pass on silence.

Presence now goes through one private `waitForPresence` asking `exists`, a query that answers false rather than failing, so it tells absence from silence. `waitUntilGone`, `appears` and `tap` share it.

Both review axes found this independently. It was invisible from inside the change, where the line reads as the seam finally paying off.

## Verification

- `JourneyReadTests`, grown from two to four, **21 s**: the read that used to throw, the read held to answering honestly for a control that is there, and now both halves of the wait — a vanished control arrives as `nil`, a present one arrives with its attributes.
- **436 unit tests in 23 s, and all five journeys.**
- The tab waits were the conversion worth doubting, since `isSelected` had only ever been read off the element — the dismissal guard was run alone first to settle that a snapshot reports it the same way.

The snapshot-polling bug also **priced itself**: `testCoreJourney` ran 135.1 s and 134.9 s with it, **123.7 s** without, against the 120.9–124.2 s #48 recorded on this machine. Eight dismissal waits taking a full snapshot every 200 ms cost about eleven seconds a run. It was visible as a number before it was understood as a defect, and was read as arXiv variance.

## What this does not close

`isHittable`. XCUITest does not carry it on a snapshot, so it cannot be read in the same query as the rest and would be a second round trip wearing `ElementState`'s clothes. Two journey lines still read it directly, both against screens nothing is removing anything from. Filed as #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6k9KkbUUZKopxq69UJaCA