### PR TITLE
A suite that forgot a model type inherited its rows (#40)

### DIFF
--- a/DEVLOG.md
+++ b/DEVLOG.md
@@ -10,6 +10,76 @@
 
 ---
 
+## 2026-08-22 — A suite that forgot a model type inherited its rows (#40)
+
+**Built**
+- **One `TestStore`, holding one in-memory container per suite and emptying it
+  before each test.** Nine suites carried a near-identical `makeContext()` —
+  fetch every model type, delete the rows, save, hand back the shared context —
+  and they disagreed about which types they bothered to clear. The disagreement
+  was silent: a suite that forgot a type passed on the previous test's rows
+  rather than failing.
+- **The model list is read back from `AppSchema` rather than written out
+  again.** That is the list #21 was about — a hand-written one at a single call
+  site migrated the store *down* to it and took the reader's installed Packs
+  with it — and the tests then hand-wrote it fourteen more times. The clear
+  walks `AppSchema.models` and opens each existential metatype far enough to
+  build its `FetchDescriptor`, so a model added to the app is cleared by every
+  suite without a test being edited. Row-by-row, not `delete(model:)`, so the
+  Article↔Concept inverse still nullifies.
+- **The process-global state a Pack install writes is cleared for every suite.**
+  Installing remembers the Pack outside the store (`ActivePackIdentity`) and
+  caches it in the process (`ActivePack`), so a suite clearing only rows starts
+  on its predecessor's Pack. Two of the nine knew that; the rest did not, and
+  which ones needed it was decided per suite by whoever wrote it — the "stays
+  true by everyone remembering it" that #36 folded away for the URLProtocol
+  stubs.
+- **Fourteen suites, not the nine the ticket counted.** Nine was the number of
+  copies *named* `makeContext`. Five more carried the same shape under
+  `freshContext`, inside `makeMap`, or inline in a test body, and
+  `WeeklyLearningIntentTests` shared a store and cleared nothing at all, staying
+  honest only by never reusing a date across two tests.
+- **What is genuinely one suite's stays in that suite**: the `builtinPackVersion`
+  stamp in `PackMigrationTests`, `PackSourceOffer.forgetDeclined()` in
+  `SourceAcquisitionTests` — a decline is written by a reader refusing an offer,
+  not by an install — and Feed sync's stub routes.
+- **`TestStoreTests` asserts the fixture** the other suites read their own
+  assertions against. In `Tests/UnitTests` rather than `Tests/Support`, because
+  `project.yml` compiles `Support` into the UI-test bundle too; the placement
+  #36 settled.
+
+Verified by the full unit suite: 436 tests in 41 suites before, 438 in 42 after,
+passing on three consecutive runs, and the UI-test target still builds. No suite
+turned out to be leaning on rows it inherited, which the ticket asked to be
+found rather than hidden — so the answer is that there was nothing to find. The
+two new tests were mutation-checked rather than trusted: dropping one model from
+the clear fails the row test, and leaving the two Pack globals set fails the
+other.
+
+**Learned: the ticket counted a spelling, and the hazard was in the shape.**
+Nine `makeContext` bodies was an exact count of one name. The same fetch-delete-
+save shape was living under five other names, and both review axes found them
+independently — which is what turned a nine-suite change into a fourteen-suite
+one. The grep that would have found them up front is for the shape (a
+`FetchDescriptor` and a `delete` inside a fixture) rather than for the helper's
+name. Worth doing on the next fold-away, because the copies that got renamed are
+exactly the ones a survey by name misses.
+
+**Learned: the suite that produced the leak was not among the nine.**
+`SeededReadingTests` installs a Pack — so it writes both globals — and cleared
+neither. Every suite the ticket named was a *consumer* defending itself against
+state someone else wrote, which is why the two that knew to clear looked like
+careful outliers rather than like the rule. A fixture that clears at the start
+of each test makes the producer/consumer distinction stop mattering, which is
+the part worth keeping: the container can be per-suite, but these two are one
+per process by definition, so clearing them for every suite is clearing them
+under the suites running alongside. What makes that safe is not the clearing but
+who reads them — only `ActivePack.inUse` reads the cache, and the two tests that
+do are synchronous `@MainActor` bodies that reach their assertion without ever
+yielding the actor.
+
+---
+
 ## 2026-08-22 — A wait is handed what a control said, not the control (#53)
 
 **Built**

--- a/TechPulse.xcodeproj/project.pbxproj
+++ b/TechPulse.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		46FE11B0203CB7421E08B2DD /* HabitEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CCF7B94959D93C993B9F598 /* HabitEngine.swift */; };
 		4823EDDF5E54AFD727A94E38 /* ExplainRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941B6A636A34EAB579EEDCC0 /* ExplainRouteTests.swift */; };
 		4903CE75CCD4D0017ED9BE27 /* MainActorStall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30BF4B81619B7930D334EA1C /* MainActorStall.swift */; };
+		499B14526AC557B4880D0436 /* TestStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4212CD4A9016E1875E246655 /* TestStoreTests.swift */; };
 		4A2B4EC62E3B4BF6E10CD9CC /* SelectableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E8740BCA165AACC9103823F /* SelectableText.swift */; };
 		4BAB76528DBE7F0990A79C24 /* HotCandidateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5879146652A224AF36498CDE /* HotCandidateTests.swift */; };
 		4BF6AF14EDF50A14C3F4205E /* TopicSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C4D1DACE42EDDAAD7384F6 /* TopicSearchService.swift */; };
@@ -65,6 +66,7 @@
 		6E32EDEC254288E369341A50 /* KnowledgeEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3217DDB8C0FCEF782C439924 /* KnowledgeEngineTests.swift */; };
 		6F940C83DBFAE7041A7EDE25 /* KnowledgePathEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFB441714355495350731A0 /* KnowledgePathEngine.swift */; };
 		71AF7B8C954EFF67E1C2E2EB /* HostPacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09ABDCB8E0521F01592F86C5 /* HostPacing.swift */; };
+		73CF179B79DE4648B4FDF8CA /* TestStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA80B754FACB341D67321AC3 /* TestStore.swift */; };
 		76300C799239920856F4869D /* IntelligenceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB39432F3B7A188E92A963D0 /* IntelligenceService.swift */; };
 		787B5A057456E5A8138E7E57 /* ProgressTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B5DEA33C7F76331B8669A39 /* ProgressTabView.swift */; };
 		7B67654466C221D28BE47D9B /* QuizEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B5916628B4441F136B85D0 /* QuizEngine.swift */; };
@@ -194,6 +196,7 @@
 		366F07A6ACC8138673869DD7 /* ai-engineer.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "ai-engineer.json"; sourceTree = "<group>"; };
 		3888CD6831CCA2655369901B /* RSSParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RSSParserTests.swift; sourceTree = "<group>"; };
 		3F5D3331A670C12BFE8FBFBC /* ConceptNeighboursTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptNeighboursTests.swift; sourceTree = "<group>"; };
+		4212CD4A9016E1875E246655 /* TestStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStoreTests.swift; sourceTree = "<group>"; };
 		43F70C6D332EB69325A6D616 /* ExplainPromptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExplainPromptTests.swift; sourceTree = "<group>"; };
 		4485958AD477220A541E32BA /* AnalysisEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalysisEligibilityTests.swift; sourceTree = "<group>"; };
 		452EC513EA805C9E22C144DB /* PackMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackMigration.swift; sourceTree = "<group>"; };
@@ -245,6 +248,7 @@
 		B2DB7FEBA756BC17F361DBE8 /* TechPulseTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = TechPulseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B598CFA675FB447CD64B2FDB /* FullMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullMapView.swift; sourceTree = "<group>"; };
 		B7AFED9D8872B5FDC7820298 /* PackRetirementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PackRetirementTests.swift; sourceTree = "<group>"; };
+		BA80B754FACB341D67321AC3 /* TestStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestStore.swift; sourceTree = "<group>"; };
 		BD1DAA70ADF0D37270B455AB /* UITestLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestLaunchTests.swift; sourceTree = "<group>"; };
 		BECB04F99A18ECBBB5965356 /* ConceptIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConceptIndex.swift; sourceTree = "<group>"; };
 		C026D81A3625A7A0FFB671BA /* PreviewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewData.swift; sourceTree = "<group>"; };
@@ -395,6 +399,8 @@
 				32A3A353D742382C897F7398 /* SourceAcquisitionTests.swift */,
 				F7F93D2B29F3C7C5529B05FD /* StubTransport.swift */,
 				DDA6B7E14E098F5F1DEB3C57 /* StubTransportTests.swift */,
+				BA80B754FACB341D67321AC3 /* TestStore.swift */,
+				4212CD4A9016E1875E246655 /* TestStoreTests.swift */,
 				F1C1E4844F48EA3BC9B6F3A3 /* TopicSearchTests.swift */,
 				BD1DAA70ADF0D37270B455AB /* UITestLaunchTests.swift */,
 				51994DA7136B4BC895E94AC8 /* WeeklyLearningIntentTests.swift */,
@@ -676,6 +682,8 @@
 				60721E7B574B899900CD070B /* SourceAcquisitionTests.swift in Sources */,
 				ADB09513CF9CF047AF2EC7FE /* StubTransport.swift in Sources */,
 				BB9B63803055DCB5A3BFDADB /* StubTransportTests.swift in Sources */,
+				73CF179B79DE4648B4FDF8CA /* TestStore.swift in Sources */,
+				499B14526AC557B4880D0436 /* TestStoreTests.swift in Sources */,
 				1E177F824E7AD32EE4346C8B /* TopicSearchTests.swift in Sources */,
 				938F03142455C084AD92D02F /* UITestLaunch.swift in Sources */,
 				0E4A760C098CAEF67AB392C1 /* UITestLaunchTests.swift in Sources */,

--- a/Tests/UnitTests/AnalysisEligibilityTests.swift
+++ b/Tests/UnitTests/AnalysisEligibilityTests.swift
@@ -11,11 +11,8 @@ import SwiftData
 @Suite("Analysis eligibility", .serialized)
 struct AnalysisEligibilityTests {
 
-    private func freshContext() throws -> ModelContext {
-        ActivePackIdentity.forget()
-        ActivePack.resetCache()
-        return ModelContext(try AppSchema.inMemoryContainer())
-    }
+    private static let store = TestStore()
+    private func freshContext() throws -> ModelContext { try Self.store.makeContext() }
 
     private func seeded(_ context: ModelContext) throws -> Article {
         try #require(try context.fetch(FetchDescriptor<Article>())

--- a/Tests/UnitTests/ConceptNeighboursTests.swift
+++ b/Tests/UnitTests/ConceptNeighboursTests.swift
@@ -10,20 +10,8 @@ import SwiftData
 struct ConceptNeighboursTests {
 
 
-    private static let sharedContainer: ModelContainer = {
-        try! AppSchema.inMemoryContainer()
-    }()
-
-    private static func freshContext() throws -> ModelContext {
-        let context = sharedContainer.mainContext
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
-        for dep in try context.fetch(FetchDescriptor<ConceptDependency>()) { context.delete(dep) }
-        for link in try context.fetch(FetchDescriptor<ConceptLink>()) { context.delete(link) }
-        for link in try context.fetch(FetchDescriptor<SemanticLink>()) { context.delete(link) }
-        for pack in try context.fetch(FetchDescriptor<InstalledPack>()) { context.delete(pack) }
-        try context.save()
-        return context
-    }
+    private static let store = TestStore()
+    private static func freshContext() throws -> ModelContext { try store.makeContext() }
 
     private func concept(_ name: String) -> Concept {
         Concept(name: name, category: "Foundations", definition: "d")

--- a/Tests/UnitTests/ExplainPromptTests.swift
+++ b/Tests/UnitTests/ExplainPromptTests.swift
@@ -164,14 +164,11 @@ struct ExplainPromptTests {
 @Suite("Explain with no model and no key", .serialized)
 struct ExplainDegradationTests {
 
-    private static let sharedContainer: ModelContainer = {
-        return try! AppSchema.inMemoryContainer()
-    }()
+    private static let store = TestStore()
 
     @Test("returns nil and writes nothing, rather than crashing")
     func definesNothing() async throws {
-        let context = Self.sharedContainer.mainContext
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
+        let context = try Self.store.makeContext()
 
         // This is the simulator's state and the reference device's state without
         // a key, but not every machine's. Where a path *is* available the call

--- a/Tests/UnitTests/ExplainRouteTests.swift
+++ b/Tests/UnitTests/ExplainRouteTests.swift
@@ -96,14 +96,10 @@ struct ConceptMatchTests {
 @Suite("Explain route", .serialized)
 struct ExplainRouteTests {
 
-    private static let sharedContainer: ModelContainer = {
-        return try! AppSchema.inMemoryContainer()
-    }()
+    private static let store = TestStore()
 
     private func makeMap() throws -> [Concept] {
-        let context = Self.sharedContainer.mainContext
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
-        try context.save()
+        let context = try Self.store.makeContext()
         for name in ["LoRA", "RAG"] {
             context.insert(Concept(name: name, category: "LLMs", definition: "d"))
         }

--- a/Tests/UnitTests/FeedSyncTests.swift
+++ b/Tests/UnitTests/FeedSyncTests.swift
@@ -25,15 +25,12 @@ import SwiftData
 @Suite("Feed sync", .serialized)
 struct FeedSyncTests {
 
-    private static let sharedContainer: ModelContainer = {
-        return try! AppSchema.inMemoryContainer()
-    }()
+    private static let store = TestStore()
 
+    /// The routes are this suite's, not the store's: a stub serves a host only
+    /// while that host has routes, and these two are the hosts it registered.
     private func makeContext() throws -> ModelContext {
-        let context = Self.sharedContainer.mainContext
-        for source in try context.fetch(FetchDescriptor<FeedSource>()) { context.delete(source) }
-        for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
-        try context.save()
+        let context = try Self.store.makeContext()
         StubTransport.stopServing(host: Self.host)
         StubTransport.stopServing(host: Self.otherHost)
         return context

--- a/Tests/UnitTests/KnowledgeEngineTests.swift
+++ b/Tests/UnitTests/KnowledgeEngineTests.swift
@@ -7,24 +7,8 @@ import SwiftData
 @Suite("Knowledge engine", .serialized)
 struct KnowledgeEngineTests {
 
-    /// One in-memory container for the whole suite: repeated ModelContainer
-    /// creation alongside the host app's live container traps in SwiftData.
-    private static let sharedContainer: ModelContainer = {
-        return try! AppSchema.inMemoryContainer()
-    }()
-
-    /// Fresh logical state per test. Row-by-row deletes (not batch) so the
-    /// Article↔Concept inverse relationship is nullified properly.
-    private func makeContext() throws -> ModelContext {
-        let context = Self.sharedContainer.mainContext
-        for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
-        for link in try context.fetch(FetchDescriptor<ConceptLink>()) { context.delete(link) }
-        for event in try context.fetch(FetchDescriptor<LearningEvent>()) { context.delete(event) }
-        for source in try context.fetch(FetchDescriptor<FeedSource>()) { context.delete(source) }
-        try context.save()
-        return context
-    }
+    private static let store = TestStore()
+    private func makeContext() throws -> ModelContext { try Self.store.makeContext() }
 
     @Test("reading an article bumps concept mastery by 0.1 and logs an event")
     func readBump() throws {

--- a/Tests/UnitTests/KnowledgePathTests.swift
+++ b/Tests/UnitTests/KnowledgePathTests.swift
@@ -7,19 +7,8 @@ import SwiftData
 @Suite("Knowledge path engine", .serialized)
 struct KnowledgePathTests {
 
-    private static let sharedContainer: ModelContainer = {
-        return try! AppSchema.inMemoryContainer()
-    }()
-
-    private func makeContext() throws -> ModelContext {
-        let context = Self.sharedContainer.mainContext
-        for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
-        for link in try context.fetch(FetchDescriptor<ConceptLink>()) { context.delete(link) }
-        for dep in try context.fetch(FetchDescriptor<ConceptDependency>()) { context.delete(dep) }
-        try context.save()
-        return context
-    }
+    private static let store = TestStore()
+    private func makeContext() throws -> ModelContext { try Self.store.makeContext() }
 
     private func concept(_ name: String, _ category: String, lit: Bool) -> Concept {
         let c = Concept(name: name, category: category, definition: "d")

--- a/Tests/UnitTests/PackInstallerTests.swift
+++ b/Tests/UnitTests/PackInstallerTests.swift
@@ -10,23 +10,8 @@ import SwiftData
 @Suite("Pack installer", .serialized)
 struct PackInstallerTests {
 
-    private static let sharedContainer: ModelContainer = {
-        return try! AppSchema.inMemoryContainer()
-    }()
-
-    private func makeContext() throws -> ModelContext {
-        let context = Self.sharedContainer.mainContext
-        for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
-        for link in try context.fetch(FetchDescriptor<ConceptLink>()) { context.delete(link) }
-        for dep in try context.fetch(FetchDescriptor<ConceptDependency>()) { context.delete(dep) }
-        for link in try context.fetch(FetchDescriptor<SemanticLink>()) { context.delete(link) }
-        for event in try context.fetch(FetchDescriptor<LearningEvent>()) { context.delete(event) }
-        for source in try context.fetch(FetchDescriptor<FeedSource>()) { context.delete(source) }
-        for pack in try context.fetch(FetchDescriptor<InstalledPack>()) { context.delete(pack) }
-        try context.save()
-        return context
-    }
+    private static let store = TestStore()
+    private func makeContext() throws -> ModelContext { try Self.store.makeContext() }
 
     // MARK: - Fixtures
 

--- a/Tests/UnitTests/PackMigrationTests.swift
+++ b/Tests/UnitTests/PackMigrationTests.swift
@@ -10,13 +10,14 @@ import SwiftData
 @Suite("Pack migration", .serialized)
 struct PackMigrationTests {
 
+    private static let store = TestStore()
+
+    /// The store's own clear takes the Pack with it; the version stamp is this
+    /// suite's, because migrating is what it is about.
     private func makeContext() throws -> ModelContext {
-        let container = try AppSchema.inMemoryContainer()
+        let context = try Self.store.makeContext()
         UserDefaults.standard.removeObject(forKey: "builtinPackVersion")
-        ActivePackIdentity.forget()
-        // The cache is process-global; a previous test's Pack must not leak in.
-        ActivePack.resetCache()
-        return ModelContext(container)
+        return context
     }
 
     /// The store as it looked before Packs were data: Concepts seeded by the

--- a/Tests/UnitTests/PackRetirementTests.swift
+++ b/Tests/UnitTests/PackRetirementTests.swift
@@ -10,26 +10,8 @@ import SwiftData
 @Suite("Pack retirement", .serialized)
 struct PackRetirementTests {
 
-    private static let sharedContainer: ModelContainer = {
-        try! AppSchema.inMemoryContainer()
-    }()
-
-    private func makeContext() throws -> ModelContext {
-        let context = Self.sharedContainer.mainContext
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
-        for dep in try context.fetch(FetchDescriptor<ConceptDependency>()) { context.delete(dep) }
-        for link in try context.fetch(FetchDescriptor<SemanticLink>()) { context.delete(link) }
-        for link in try context.fetch(FetchDescriptor<ConceptLink>()) { context.delete(link) }
-        for event in try context.fetch(FetchDescriptor<LearningEvent>()) { context.delete(event) }
-        for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
-        for pack in try context.fetch(FetchDescriptor<InstalledPack>()) { context.delete(pack) }
-        try context.save()
-        // Install writes both of these; leaving them set would hand the next
-        // suite a Pack this one installed.
-        ActivePackIdentity.forget()
-        ActivePack.resetCache()
-        return context
-    }
+    private static let store = TestStore()
+    private func makeContext() throws -> ModelContext { try Self.store.makeContext() }
 
     private func pack(field: String, concept: String) -> PackFile {
         PackFile(field: field, specialtyCluster: nil,

--- a/Tests/UnitTests/PackSelectionTests.swift
+++ b/Tests/UnitTests/PackSelectionTests.swift
@@ -10,11 +10,8 @@ import SwiftData
 @Suite("Choosing a Pack", .serialized)
 struct PackSelectionTests {
 
-    private func makeContext() throws -> ModelContext {
-        let container = try AppSchema.inMemoryContainer()
-        ActivePack.resetCache()
-        return ModelContext(container)
-    }
+    private static let store = TestStore()
+    private func makeContext() throws -> ModelContext { try Self.store.makeContext() }
 
     private func concept(_ name: String, in context: ModelContext) throws -> Concept? {
         try context.fetch(FetchDescriptor<Concept>()).first { $0.name == name }

--- a/Tests/UnitTests/ResponseLimitTests.swift
+++ b/Tests/UnitTests/ResponseLimitTests.swift
@@ -85,17 +85,8 @@ struct TopicSearchCapTests {
         StubTransport.stopServing(host: Self.queryURL.host()!)
     }
 
-    private static let sharedContainer: ModelContainer = {
-        return try! AppSchema.inMemoryContainer()
-    }()
-
-    private func makeContext() throws -> ModelContext {
-        let context = Self.sharedContainer.mainContext
-        for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
-        try context.save()
-        return context
-    }
+    private static let store = TestStore()
+    private func makeContext() throws -> ModelContext { try Self.store.makeContext() }
 
     /// A valid Atom entry, padded past the cap by a comment the parser would
     /// otherwise skip — so the *only* reason to refuse it is its size.

--- a/Tests/UnitTests/SeededReadingTests.swift
+++ b/Tests/UnitTests/SeededReadingTests.swift
@@ -13,21 +13,8 @@ import SwiftData
 @Suite("Seeded reading", .serialized)
 struct SeededReadingTests {
 
-    private static let sharedContainer: ModelContainer = {
-        try! AppSchema.inMemoryContainer()
-    }()
-
-    private static func freshContext() throws -> ModelContext {
-        let context = sharedContainer.mainContext
-        for article in try context.fetch(FetchDescriptor<Article>()) { context.delete(article) }
-        for concept in try context.fetch(FetchDescriptor<Concept>()) { context.delete(concept) }
-        for dep in try context.fetch(FetchDescriptor<ConceptDependency>()) { context.delete(dep) }
-        for link in try context.fetch(FetchDescriptor<ConceptLink>()) { context.delete(link) }
-        for link in try context.fetch(FetchDescriptor<SemanticLink>()) { context.delete(link) }
-        for pack in try context.fetch(FetchDescriptor<InstalledPack>()) { context.delete(pack) }
-        try context.save()
-        return context
-    }
+    private static let store = TestStore()
+    private static func freshContext() throws -> ModelContext { try store.makeContext() }
 
     private func installedFlagship(_ context: ModelContext) throws {
         try PackInstaller.install(try BuiltinPacks.aiEngineer(), origin: .builtin, context: context)

--- a/Tests/UnitTests/SourceAcquisitionTests.swift
+++ b/Tests/UnitTests/SourceAcquisitionTests.swift
@@ -13,11 +13,14 @@ import SwiftData
 @Suite("Acquiring a Source", .serialized)
 struct SourceAcquisitionTests {
 
+    private static let store = TestStore()
+
+    /// A declined suggestion is written by the reader refusing an offer rather
+    /// than by an install, so forgetting it is this suite's own business.
     private func makeContext() throws -> ModelContext {
-        let container = try AppSchema.inMemoryContainer()
-        ActivePack.resetCache()
+        let context = try Self.store.makeContext()
         PackSourceOffer.forgetDeclined()
-        return ModelContext(container)
+        return context
     }
 
     private func aiEngineer() throws -> PackFile { try BuiltinPacks.aiEngineer() }

--- a/Tests/UnitTests/TestStore.swift
+++ b/Tests/UnitTests/TestStore.swift
@@ -1,0 +1,79 @@
+import Foundation
+import SwiftData
+@testable import TechPulse
+
+/// The store a unit suite runs against: one in-memory container, held for the
+/// suite, emptied before each test.
+///
+/// Nine suites carried a copy of this before (#40) — fetch every model type,
+/// delete the rows, save, hand back the context — and five more carried it
+/// under another name. They disagreed about which types they bothered to clear,
+/// and the disagreement was silent: a suite that forgot a type inherited the
+/// previous test's rows rather than failing. A fifteenth shared a store and
+/// cleared nothing at all, staying honest only by never reusing a date.
+///
+/// Two things follow from that, and they are what this type is for:
+///
+/// - **The model list comes from `AppSchema`.** `AppSchema` names the app's
+///   models once, which is what #21 was about — a hand-written list at one call
+///   site migrated the store *down* to it and dropped the reader's installed
+///   Packs. The tests then hand-wrote that list fourteen more times. Reading it back
+///   from the schema means a model added to the app is cleared by every suite
+///   without anyone editing a test.
+/// - **The process-global state a Pack install writes is cleared too.**
+///   Installing a Pack remembers the Pack outside the store
+///   (`ActivePackIdentity`) and caches it in the process (`ActivePack`), so a
+///   suite that clears only rows starts on the Pack its predecessor installed.
+///   Two of them knew that and the rest didn't, which is the "stays true by
+///   everyone remembering it" that #36 folded away for the URLProtocol stubs.
+///
+/// One container per suite rather than one for the test run: Swift Testing runs
+/// suites in parallel even when each is `.serialized` within itself, and rows
+/// cleared out from under a suite that is mid-test would be a flake nobody
+/// could read. Reused *within* a suite because repeated `ModelContainer`
+/// creation alongside the host app's live container traps in SwiftData, and
+/// because clearing is what keeps these suites fast.
+///
+/// The two globals are the exception, and they cannot be given the same
+/// treatment: they are one per process by definition, so clearing them for
+/// every suite is clearing them under the suites running alongside. What makes
+/// that safe is not the clearing but who reads them. `ActivePack.load(context:)`
+/// fetches from the context it is handed, so a suite asserting on the Pack it
+/// installed reads its own store; only `ActivePack.inUse` reads the cache, and
+/// the two tests that do are synchronous `@MainActor` bodies, which reach their
+/// assertion without ever yielding the actor.
+@MainActor
+struct TestStore {
+
+    private let container: ModelContainer
+
+    init() {
+        container = try! AppSchema.inMemoryContainer()
+    }
+
+    /// A context with no rows in it and no Pack remembered — whatever the last
+    /// test did.
+    ///
+    /// Row-by-row deletes rather than `delete(model:)`, so the Article↔Concept
+    /// inverse relationship is nullified properly.
+    func makeContext() throws -> ModelContext {
+        let context = container.mainContext
+        for model in AppSchema.models {
+            try Self.deleteRows(of: model, in: context)
+        }
+        try context.save()
+        // Cleared after the rows, not before: what these two remember is the
+        // Pack the rows described.
+        ActivePackIdentity.forget()
+        ActivePack.resetCache()
+        return context
+    }
+
+    /// Opens one of `AppSchema.models` — which is a list of existential
+    /// metatypes — far enough to build the `FetchDescriptor` its rows need.
+    private static func deleteRows<Model: PersistentModel>(
+        of type: Model.Type, in context: ModelContext
+    ) throws {
+        for row in try context.fetch(FetchDescriptor<Model>()) { context.delete(row) }
+    }
+}

--- a/Tests/UnitTests/TestStoreTests.swift
+++ b/Tests/UnitTests/TestStoreTests.swift
@@ -1,0 +1,108 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import TechPulse
+
+/// The fixture the other suites rest on, asserted rather than assumed (#40).
+///
+/// Every suite that uses `TestStore` reads its own assertions as "given a store
+/// with nothing in it". Nine hand-written copies of that promise each kept it
+/// to a different extent, so it is worth one suite of its own.
+@MainActor
+@Suite("Test store", .serialized)
+struct TestStoreTests {
+
+    private static let store = TestStore()
+    private func makeContext() throws -> ModelContext { try Self.store.makeContext() }
+
+    /// One row of every model the schema names, so the clear has something of
+    /// each to miss. Written out because a row has to be constructed — what
+    /// must not be written out is the list the *clear* walks, and that comes
+    /// from `AppSchema`.
+    ///
+    /// Returns the models it seeded, taken from the rows themselves rather than
+    /// listed a second time. The premise below is about this fixture and not
+    /// about the schema: a model added to `AppSchema` is cleared by derivation,
+    /// seeded here or not.
+    private func seedEveryTable(_ context: ModelContext) -> Set<String> {
+        var seeded: Set<String> = []
+        func insert<Model: PersistentModel>(_ row: Model) {
+            context.insert(row)
+            seeded.insert(String(describing: Model.self))
+        }
+        let concept = Concept(name: "Attention", category: "Foundations", definition: "d")
+        let article = Article(guid: "g", title: "t", content: "c",
+                              publishedAt: .now, sourceName: "s")
+        article.concepts = [concept]
+        insert(concept)
+        insert(article)
+        insert(FeedSource(name: "Feed", url: URL(string: "https://feeds.test/a.xml")!,
+                          category: "Foundations"))
+        insert(LearningEvent(kind: "read", conceptName: "Attention", masteryDelta: 0.1))
+        insert(ConceptLink(conceptA: "Attention", conceptB: "Embeddings"))
+        insert(ConceptDependency(prerequisite: "Embeddings", dependent: "Attention"))
+        insert(SemanticLink(conceptA: "Attention", conceptB: "Embeddings", strength: 0.5))
+        insert(InstalledPack(field: "AI Engineering", specialtyCluster: nil,
+                             clusterOrder: ["Foundations"], stages: [],
+                             suggestedSources: [], conceptNames: ["Attention"],
+                             sideQuestConcepts: [], origin: .builtin))
+        return seeded
+    }
+
+    private func rowCounts(_ context: ModelContext) throws -> [String: Int] {
+        var counts: [String: Int] = [:]
+        for model in AppSchema.models {
+            counts[String(describing: model)] = try Self.count(of: model, in: context)
+        }
+        return counts
+    }
+
+    /// Opens a model the same way `TestStore` does, deliberately rather than by
+    /// borrowing its opener: a test that counted rows through the code under
+    /// test would agree with it by construction.
+    private static func count<Model: PersistentModel>(
+        of type: Model.Type, in context: ModelContext
+    ) throws -> Int {
+        try context.fetchCount(FetchDescriptor<Model>())
+    }
+
+    // MARK: - Rows
+
+    @Test("a context arrives with no rows of any model the schema names")
+    func everyTableIsCleared() throws {
+        let dirty = try makeContext()
+        let seeded = seedEveryTable(dirty)
+        try dirty.save()
+        let filled = try rowCounts(dirty).filter { $0.value > 0 }
+        #expect(Set(filled.keys) == seeded,
+                "the premise: every table this fixture seeds has something in it to be missed")
+
+        let fresh = try makeContext()
+
+        // Counted over `AppSchema`, so this assertion covers a model added to
+        // the app without being widened by hand.
+        let left = try rowCounts(fresh).filter { $0.value > 0 }
+        #expect(left.isEmpty, "rows inherited from the previous test: \(left)")
+    }
+
+    // MARK: - What a Pack install writes outside the store
+
+    @Test("the Pack the last test installed is not the next test's Active Pack")
+    func packStateIsCleared() throws {
+        let context = try makeContext()
+        try PackInstaller.install(
+            PackFile(field: "Baking", specialtyCluster: nil, clusterOrder: ["Ingredients"],
+                     concepts: [.init(name: "Flour", cluster: "Ingredients",
+                                      definition: "d", dependencies: [])],
+                     stages: [], suggestedSources: []),
+            origin: .imported, context: context)
+        #expect(ActivePack.load(context: context)?.field == "Baking", "the premise")
+        #expect(ActivePackIdentity.recalled?.field == "Baking", "the premise")
+
+        let fresh = try makeContext()
+
+        #expect(ActivePack.load(context: fresh) == nil)
+        #expect(ActivePackIdentity.recalled == nil,
+                "a Pack remembered outside the store outlives the rows that described it")
+    }
+}

--- a/Tests/UnitTests/WeeklyLearningIntentTests.swift
+++ b/Tests/UnitTests/WeeklyLearningIntentTests.swift
@@ -11,13 +11,9 @@ import SwiftData
 @Suite("Weekly learning intent", .serialized)
 struct WeeklyLearningIntentTests {
 
-    /// One container for the whole suite, as every other suite here does:
-    /// repeated `ModelContainer` creation alongside the host app's live
-    /// container traps in SwiftData (see `KnowledgeEngineTests`). Only the test
-    /// that has to see the store on disk opens a second one.
-    private static let sharedContainer: ModelContainer = {
-        try! AppSchema.inMemoryContainer()
-    }()
+    /// One store for the whole suite, as every other suite here has. Only the
+    /// test that has to see the store on disk opens a container of its own.
+    private static let store = TestStore()
 
     /// A Pack the app would recognise, retired so it can't become the Active
     /// Pack of whatever runs against this store next.
@@ -60,7 +56,7 @@ struct WeeklyLearningIntentTests {
 
     @Test("reports the Concepts advanced in the last seven days, and only those")
     func reportsTheWeeksConcepts() throws {
-        let context = ModelContext(Self.sharedContainer)
+        let context = try Self.store.makeContext()
         let now = Date(timeIntervalSince1970: 1_770_000_000)
         for event in [
             LearningEvent(kind: "read", conceptName: "Attention", masteryDelta: 0.2,
@@ -80,7 +76,7 @@ struct WeeklyLearningIntentTests {
 
     @Test("names a Concept once however many readings advanced it")
     func namesEachConceptOnce() throws {
-        let context = ModelContext(Self.sharedContainer)
+        let context = try Self.store.makeContext()
         let now = Date(timeIntervalSince1970: 1_780_000_000)
         for delta in [0.1, 0.1, 0.3] {
             context.insert(LearningEvent(kind: "read", conceptName: "Attention",


### PR DESCRIPTION
Closes #40.

Nine unit suites carried a near-identical `makeContext()` — fetch every model type, delete the rows, save, hand back the shared in-memory context — and they disagreed about which types they bothered to clear. The disagreement was silent: a suite that forgot a type passed on the previous test's rows rather than failing.

### What changed

- **One `TestStore`**, holding one in-memory container per suite and emptying it before each test.
- **The model list is read back from `AppSchema`** rather than written out again — the list #21 was about, which the tests then hand-wrote fourteen more times. The clear walks `AppSchema.models` and opens each existential metatype far enough to build its `FetchDescriptor`, so a model added to the app is cleared by every suite without a test being edited. Row-by-row, not `delete(model:)`, so the Article↔Concept inverse still nullifies.
- **The process-global state a Pack install writes is cleared for every suite** (`ActivePackIdentity`, `ActivePack`'s cache). Two of the nine knew to do that; the rest did not, and which ones needed it was decided per suite by whoever wrote it.
- **Fourteen suites, not the nine the ticket counted.** Nine was the number of copies *named* `makeContext`. Five more carried the same shape under `freshContext`, inside `makeMap`, or inline in a test body, and `WeeklyLearningIntentTests` shared a store and cleared nothing at all, staying honest only by never reusing a date across two tests. Both review axes found these independently.
- **What is genuinely one suite's stays in that suite**: the `builtinPackVersion` stamp, `PackSourceOffer.forgetDeclined()` — a decline is written by a reader refusing an offer, not by an install — and Feed sync's stub routes.
- `TestStore` and `TestStoreTests` sit in `Tests/UnitTests`, not `Tests/Support`, because `project.yml` compiles `Support` into the UI-test bundle too — the placement #36 settled.

### Verification

436 tests in 41 suites before, **438 in 42 after**, passing on three consecutive runs plus once more after this branch was rebased onto `main`; the UI-test target still builds. No suite turned out to be leaning on rows it inherited, so the ticket's "a suite that relied on inherited rows is found rather than hidden" has nothing to report.

The two new tests were mutation-checked rather than trusted: dropping one model from the clear fails the row test, and leaving the two Pack globals set fails the other.

### Worth a reviewer's eye

`PackMigrationTests`, `PackSelectionTests` and `SourceAcquisitionTests` built a fresh `ModelContainer` per test and now share one per suite. The ticket marks the shared-container pattern out of scope; I read that as endorsing the pattern rather than freezing which suites use it, but it is the one place this change alters isolation rather than only removing duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6k9KkbUUZKopxq69UJaCA