### PR TITLE
An agent looking for AGENTS.md is sent to CLAUDE.md, not to a copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# TechPulse — agent instructions
+
+See [CLAUDE.md](CLAUDE.md).
+
+It is the source of truth. This file exists so that an agent looking for
+`AGENTS.md` is sent there, rather than finding a second copy of the same
+instructions — which is what it was, byte for byte, and what would have drifted
+the first time either file was edited.


### PR DESCRIPTION
`AGENTS.md` was an untracked, byte-identical copy of `CLAUDE.md` — 385 bytes, never committed.

Two files carrying the same instructions have one failure mode and it is silent: an edit lands in one of them, the agent that reads the other keeps following what the project used to say, and nothing anywhere reports a disagreement.

It is a pointer now, and committed, so the copy cannot come back. `CLAUDE.md` stays the source of truth and is unchanged.

No `DEVLOG.md` entry: this is documentation rather than development, matching `487056d` and `b3f4334`, the two doc-only commits in the history that also skip it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6k9KkbUUZKopxq69UJaCA